### PR TITLE
Change job `check-oidc` name to `sign-job`.

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -124,6 +124,10 @@ jobs:
     - name: Verify the image with cosign
       working-directory: ./src/github.com/vaikas/sigstore-scaffolding
       run: |
+        # Grab the secret from the fulcio-system namespace and make a copy
+        # in our namespace so we can get access to the Fulcio public key
+        # so we can verify against it.
+        kubectl -n fulcio-system get secrets fulcio-secret -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl apply -f -
         ko apply -f ./testdata/config/verify-job
 
         kubectl wait --for=condition=Complete --timeout=180s job/verify-job

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -112,7 +112,7 @@ jobs:
 
         ko apply -f ./testdata/config/sign-job
 
-        kubectl wait --for=condition=Complete --timeout=90s job/check-oidc
+        kubectl wait --for=condition=Complete --timeout=90s job/sign-job
 
     - name: Check that an entry was created in Rekor
       working-directory: ./src/github.com/vaikas/sigstore-scaffolding
@@ -120,6 +120,13 @@ jobs:
         ko apply -f ./testdata/config/checktree
 
         kubectl wait --for=condition=Complete --timeout=90s job/checktree
+
+    - name: Verify the image with cosign
+      working-directory: ./src/github.com/vaikas/sigstore-scaffolding
+      run: |
+        ko apply -f ./testdata/config/verify-job
+
+        kubectl wait --for=condition=Complete --timeout=180s job/verify-job
 
     - name: Collect node diagnostics
       if: ${{ failure() }}

--- a/config/fulcio/fulcio/300-fulcio.yaml
+++ b/config/fulcio/fulcio/300-fulcio.yaml
@@ -17,7 +17,8 @@ spec:
       # This doesn't actually use Kubernetes credentials, so don't mount them in.
       automountServiceAccountToken: false
       containers:
-      - image: gcr.io/projectsigstore/fulcio@sha256:66870bd6b111f3c5478703a8fb31c062003f0127b2c2c5e49ccd82abc4ec7841
+      # v0.2.0
+      - image: gcr.io/projectsigstore/fulcio@sha256:5e4b883737007224a4a7aad2957d1d2d809c8fc81dae30079914cd8142e6ac8c
         name: fulcio
         ports:
         - containerPort: 5555

--- a/getting-started.md
+++ b/getting-started.md
@@ -254,5 +254,5 @@ for cosign you have to use `--allow-insecure-flag` in your cosign invocations.
 For example, to verify an image hosted in the local registry:
 
 ```shell
-COSIGN_EXPERIMENTAL=1 ./main verify --allow-insecure-registry  registry.local:5000/knative/pythontest@sha256:080c3ad99fdd8b6f23da3085fb321d8a4fa57f8d4dd30135132e0fe3b31aa602
+SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY=1 COSIGN_EXPERIMENTAL=1 cosign verify --rekor-url=http://rekor.rekor-system.svc:8080 --allow-insecure-registry registry.local:5000/knative/pythontest@sha256:080c3ad99fdd8b6f23da3085fb321d8a4fa57f8d4dd30135132e0fe3b31aa602
 ```

--- a/getting-started.md
+++ b/getting-started.md
@@ -60,7 +60,7 @@ three distinct steps.
         # so we can verify the SCT coming from there.
         kubectl -n ctlog-system get secrets ctlog-public-key -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl apply -f -
         curl -L https://github.com/sigstore/scaffolding/releases/download/${{ env.SIGSTORE_SCAFFOLDING_RELEASE_VERSION }}/testrelease.yaml | kubectl create -f -
-        kubectl wait --for=condition=Complete --timeout=90s job/check-oidc
+        kubectl wait --for=condition=Complete --timeout=90s job/sign-job
         kubectl wait --for=condition=Complete --timeout=90s job/checktree
 ```
 
@@ -179,14 +179,16 @@ sure that the rekor entry is created for it.
 kubectl -n ctlog-system get secrets ctlog-public-key -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl apply -f -
 ```
 
-2) Create the two test jobs (checktree and check-oidc)  using this yaml (this may take a bit (~couple of minutes), since the two jobs are launched simultaneously)
+2) Create the three test jobs (checktree, sign-job, and verify-job)  using this
+yaml (this may take a bit (~couple of minutes), since the jobs are launched
+simultaneously)
 ```shell
 curl -L https://github.com/sigstore/scaffolding/releases/download/v0.2.0/testrelease.yaml | kubectl apply -f -
 ```
 
 3) To view if jobs have completed
 ```shell
-kubectl wait --timeout=5m --for=condition=Complete jobs checktree check-oidc
+kubectl wait --timeout=5m --for=condition=Complete jobs checktree sign-job verify-job
 ```
 
 ## Exercising the local cluster

--- a/testdata/config/verify-job/placeholder.go
+++ b/testdata/config/verify-job/placeholder.go
@@ -1,0 +1,15 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signjob

--- a/testdata/config/verify-job/verify-job.yaml
+++ b/testdata/config/verify-job/verify-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sign-job
+  name: verify-job
 spec:
   template:
     spec:
@@ -13,13 +13,15 @@ spec:
         # Built from ci on 2022-03-15
         image: gcr.io/projectsigstore/cosign/ci/cosign@sha256:8f7f1a0e7cef67c352f00acd14791d977faa8d1cd47a69f9c880a5185c44ffbb
         args: [
-          "sign",
-          "--fulcio-url", "http://fulcio.fulcio-system.svc",
+          "verify",
           "--rekor-url", "http://rekor.rekor-system.svc",
-          "--force",
+          "--allow-insecure-registry",
           "ko://github.com/sigstore/scaffolding/cmd/rekor/checktree",
         ]
         env:
+        # Trust the Rekor public key that is fetched from it.
+        - name: SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY
+          value: "true"
         - name: COSIGN_EXPERIMENTAL
           value: "true"
         - name: SIGSTORE_CT_LOG_PUBLIC_KEY_FILE

--- a/testdata/config/verify-job/verify-job.yaml
+++ b/testdata/config/verify-job/verify-job.yaml
@@ -24,15 +24,15 @@ spec:
           value: "true"
         - name: COSIGN_EXPERIMENTAL
           value: "true"
-        - name: SIGSTORE_CT_LOG_PUBLIC_KEY_FILE
-          value: "/var/run/sigstore-root/rootfile.pem"
+        - name: SIGSTORE_ROOT_FILE
+          value: "/var/run/sigstore-fulcio/fulcio-public.pem"
         - name: COSIGN_REPOSITORY
           value: "registry.local:5000/knative"
         volumeMounts:
         - name: oidc-info
           mountPath: /var/run/sigstore/cosign
         - name: keys
-          mountPath: "/var/run/sigstore-root"
+          mountPath: "/var/run/sigstore-fulcio"
           readOnly: true
       volumes:
         - name: oidc-info
@@ -44,7 +44,7 @@ spec:
                   audience: sigstore
         - name: keys
           secret:
-            secretName: ctlog-public-key
+            secretName: fulcio-secret
             items:
-            - key: public
-              path: rootfile.pem
+            - key: cert
+              path: fulcio-public.pem


### PR DESCRIPTION
Add `verify-job` job which will run cosign verify.
Bump Fulcio to v0.2.0 release.
Update cosign containers to latest CI builds to pick up
https://github.com/sigstore/cosign/pull/1610

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary

Complete the verification by running the cosign verify on the image that was signed.
Bump fulcio to released v0.2.0 version


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Rename test job `check-oidc` to `sign-job`
Introduce a test job `verify-job` that uses cosign verify to verify the signed image.
```
