### PR TITLE
Use apko as base image and add version information

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -122,7 +122,7 @@ jobs:
       working-directory: ./src/github.com/sigstore/scaffolding
       timeout-minutes: 20
       run: |
-        ko apply -BRf ./config/
+        make ko-apply
 
         # Make sure the jobs that are required to finish do so.
         # Note we delete the jobs after they complete because otherwise
@@ -147,14 +147,14 @@ jobs:
         # so we can verify the SCT coming from there.
         kubectl -n ctlog-system get secrets ctlog-public-key -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl apply -f -
 
-        ko apply -f ./testdata/config/sign-job
+        make ko-apply-sign-job
 
         kubectl wait --for=condition=Complete --timeout=90s job/sign-job
 
     - name: Check that an entry was created in Rekor
       working-directory: ./src/github.com/sigstore/scaffolding
       run: |
-        ko apply -f ./testdata/config/checktree
+        make ko-apply-checktree
 
         kubectl wait --for=condition=Complete --timeout=90s job/checktree
 
@@ -165,14 +165,15 @@ jobs:
         # in our namespace so we can get access to the Fulcio public key
         # so we can verify against it.
         kubectl -n fulcio-system get secrets fulcio-secret -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl apply -f -
-        ko apply -f ./testdata/config/verify-job
+
+        make ko-apply-verify-job
 
         kubectl wait --for=condition=Complete --timeout=180s job/verify-job
 
     # TODO(vaikas): There should be a fake issuer on the cluster
     - name: Install a Knative service for fetch tokens off the cluster
       run: |
-        ko apply -f ./testdata/config/gettoken
+        make ko-apply-gettoken
         sleep 2
         kubectl wait --for=condition=Ready --timeout=15s ksvc gettoken
 

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: gcr.io/distroless/base:nonroot
+defaultBaseImage: ghcr.io/chainguard-dev/apko:v0.2.2
 
 builds:
 - id: ctlog

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -14,6 +14,7 @@ builds:
   - -s
   - -w
   - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
 
 - id: fulcio
   dir: .
@@ -28,6 +29,7 @@ builds:
   - -s
   - -w
   - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
 
 - id: rekor
   dir: .
@@ -42,6 +44,7 @@ builds:
   - -s
   - -w
   - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
 
 - id: trillian
   dir: .
@@ -56,3 +59,19 @@ builds:
   - -s
   - -w
   - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
+
+- id: getoidctoken
+  dir: .
+  main: ./cmd/getoidctoken
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - -tags
+  - nostackdriver
+  ldflags:
+  - -s
+  - -w
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,31 @@ sign-images:
 
 .PHONY: release-images
 release-images: ko-resolve ko-resolve-testdata
+
+
+### Testing
+
+.PHONY: ko-apply
+ko-apply:
+	LDFLAGS="$(LDFLAGS)" \
+	ko apply -BRf ./config/
+
+.PHONY: ko-apply-sign-job
+ko-apply-sign-job:
+	LDFLAGS="$(LDFLAGS)" \
+	ko apply -f ./testdata/config/sign-job
+
+.PHONY: ko-apply-verify-job
+ko-apply-verify-job:
+	LDFLAGS="$(LDFLAGS)" \
+	ko apply -f ./testdata/config/verify-job
+
+.PHONY: ko-apply-gettoken
+ko-apply-gettoken:
+	LDFLAGS="$(LDFLAGS)" \
+	ko apply -f ./testdata/config/gettoken
+
+.PHONY: ko-apply-checktree
+ko-apply-checktree:
+	LDFLAGS="$(LDFLAGS)" \
+	ko apply -f ./testdata/config/checktree

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,36 @@
 GIT_HASH ?= $(shell git rev-parse HEAD)
 GIT_TAG ?= $(shell git describe --tags --always --dirty)
+DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+GIT_TREESTATE = "clean"
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
+LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_TAG) \
+        -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
+        -X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
+        -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
+
 KO_DOCKER_REPO ?= ghcr.io/sigstore/scaffolding
 
 .PHONY: ko-resolve
 ko-resolve:
 	# "Doing ko resolve for config"
 	# "Build a big bundle of joy, this also produces SBOMs"
+	LDFLAGS="$(LDFLAGS)" \
 	ko resolve --tags $(GIT_TAG),latest --base-import-paths --recursive --filename ./config --platform=all --image-refs imagerefs > release.yaml
 
 .PHONY: ko-resolve-testdata
 ko-resolve-testdata:
 	# "Doing ko resolve for testdata"
 	# "Build a big bundle of joy, this also produces SBOMs"
+	LDFLAGS="$(LDFLAGS)" \
 	ko resolve --tags $(GIT_TAG),latest --base-import-paths --recursive --filename ./testdata --platform=all --image-refs testimagerefs > testrelease.yaml
 
 imagerefs := $(shell cat imagerefs testimagerefs)

--- a/cmd/ctlog/createctconfig/main.go
+++ b/cmd/ctlog/createctconfig/main.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+	"sigs.k8s.io/release-utils/version"
 )
 
 const (
@@ -59,7 +60,12 @@ var (
 
 func main() {
 	flag.Parse()
+
 	ctx := signals.NewContext()
+
+	versionInfo := version.GetVersionInfo()
+	logging.FromContext(ctx).Infof("running create_ct_config Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		logging.FromContext(ctx).Panicf("Failed to get InClusterConfig: %v", err)

--- a/cmd/fulcio/createcerts/main.go
+++ b/cmd/fulcio/createcerts/main.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+	"sigs.k8s.io/release-utils/version"
 )
 
 const (
@@ -53,6 +54,10 @@ func main() {
 		panic("env variable NAMESPACE must be set")
 	}
 	ctx := signals.NewContext()
+
+	versionInfo := version.GetVersionInfo()
+	logging.FromContext(ctx).Infof("running create_certs Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		logging.FromContext(ctx).Panicf("Failed to get InClusterConfig: %v", err)

--- a/cmd/getoidctoken/main.go
+++ b/cmd/getoidctoken/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/kelseyhightower/envconfig"
+	"sigs.k8s.io/release-utils/version"
 )
 
 type envConfig struct {
@@ -51,6 +52,10 @@ func main() {
 	if err := envconfig.Process("", &env); err != nil {
 		log.Fatalf("failed to process env var: %s", err)
 	}
+
+	versionInfo := version.GetVersionInfo()
+	log.Printf("running get_oidc_token Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+
 	http.HandleFunc("/", tokenWriter(env.FileName))
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		panic(err)

--- a/cmd/rekor/checktree/main.go
+++ b/cmd/rekor/checktree/main.go
@@ -31,7 +31,9 @@ import (
 	"github.com/sigstore/rekor/pkg/types"
 	"github.com/sigstore/rekor/pkg/types/hashedrekord"
 	hrv001 "github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+	"sigs.k8s.io/release-utils/version"
 )
 
 var (
@@ -45,6 +47,9 @@ func main() {
 	}
 
 	ctx := signals.NewContext()
+	versionInfo := version.GetVersionInfo()
+	logging.FromContext(ctx).Infof("running create_check_tree Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+
 	c, err := client.GetRekorClient(*rekorURL)
 	if err != nil {
 		log.Panic("Failed to construct rekor client", err)

--- a/cmd/trillian/createtree/main.go
+++ b/cmd/trillian/createtree/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+	"sigs.k8s.io/release-utils/version"
 )
 
 const (
@@ -52,6 +53,9 @@ var (
 func main() {
 	flag.Parse()
 	ctx := signals.NewContext()
+	versionInfo := version.GetVersionInfo()
+	logging.FromContext(ctx).Infof("running create_tree Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		logging.FromContext(ctx).Fatalf("Failed to get InClusterConfig: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/code-generator v0.23.5
 	knative.dev/hack v0.0.0-20220111151514-59b0cf17578e
 	knative.dev/pkg v0.0.0-20220112181951-2b23ad111bc2
+	sigs.k8s.io/release-utils v0.6.0
 )
 
 require (
@@ -45,6 +46,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 // indirect
 	github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490 // indirect
+	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/coreos/go-oidc/v3 v3.1.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
@@ -122,7 +124,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.3.0 // indirect
+	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.10.1 // indirect
@@ -161,15 +163,15 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.20.0 // indirect
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
-	golang.org/x/mod v0.5.1 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
+	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
-	golang.org/x/tools v0.1.8 // indirect
+	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/api v0.64.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOi
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
@@ -1538,6 +1540,8 @@ github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSW
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/cobra v1.3.0 h1:R7cSvGu+Vv+qX0gW5R/85dx2kmmJT5z5NM8ifdYjdn0=
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
+github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -1870,6 +1874,8 @@ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -2125,6 +2131,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t3cHp9ZpwcdjqyEWLlo=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 h1:A9i04dxx7Cribqbs8jf3FQLogkL/CV2YN7hj9KWJCkc=
+golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -2238,6 +2246,7 @@ golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff/go.mod h1:YD9qOF0M9xpSpd
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
 golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -2587,6 +2596,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
+sigs.k8s.io/release-utils v0.6.0 h1:wJDuzWJqPH4a5FAxAXE2aBvbB6UMIW7iYMhsKnIMQkA=
+sigs.k8s.io/release-utils v0.6.0/go.mod h1:kR1/DuYCJ4covppUasYNcA11OixC9O37B/E0ejRfb+c=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=


### PR DESCRIPTION
#### Summary
- use apko v0.2.2 as base image
- output version information when the service start

#### Ticket Link
N/A

#### Release Note

```release-note
- use apko v0.2.2 as base image
- output version information when the service start
```
