### PR TITLE
Resurrect trillian createdb

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -46,9 +46,24 @@ builds:
   - -extldflags "-static"
   - "{{ .Env.LDFLAGS }}"
 
-- id: trillian
+- id: trillian-createtree
   dir: .
   main: ./cmd/trillian/createtree
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - -tags
+  - nostackdriver
+  ldflags:
+  - -s
+  - -w
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
+
+- id: trillian-createdb
+  dir: .
+  main: ./cmd/trillian/createdb
   env:
   - CGO_ENABLED=0
   flags:

--- a/cmd/trillian/createdb/main.go
+++ b/cmd/trillian/createdb/main.go
@@ -1,0 +1,305 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
+)
+
+// These are from the Trillian schema, with the comments removed.
+// https://github.com/google/trillian/blob/master/storage/mysql/schema/storage.sql
+const (
+	// This is used to query to see if there are indices on a particular table.
+	indexCheck = `
+	select count(*) from information_schema.statistics where table_schema = ? and table_name=? and index_name=?;
+	`
+	createTableTrees = `
+	CREATE TABLE IF NOT EXISTS Trees(
+	  TreeId                BIGINT NOT NULL,
+	  TreeState             ENUM('ACTIVE', 'FROZEN', 'DRAINING') NOT NULL,
+	  TreeType              ENUM('LOG', 'MAP', 'PREORDERED_LOG') NOT NULL,
+	  HashStrategy          ENUM('RFC6962_SHA256', 'TEST_MAP_HASHER', 'OBJECT_RFC6962_SHA256', 'CONIKS_SHA512_256', 'CONIKS_SHA256') NOT NULL,
+	  HashAlgorithm         ENUM('SHA256') NOT NULL,
+	  SignatureAlgorithm    ENUM('ECDSA', 'RSA', 'ED25519') NOT NULL,
+	  DisplayName           VARCHAR(20),
+	  Description           VARCHAR(200),
+	  CreateTimeMillis      BIGINT NOT NULL,
+	  UpdateTimeMillis      BIGINT NOT NULL,
+	  MaxRootDurationMillis BIGINT NOT NULL,
+	  PrivateKey            MEDIUMBLOB NOT NULL,
+	  PublicKey             MEDIUMBLOB NOT NULL,
+	  Deleted               BOOLEAN,
+	  DeleteTimeMillis      BIGINT,
+	  PRIMARY KEY(TreeId)
+	);
+`
+
+	createTableTreeControl = `
+	CREATE TABLE IF NOT EXISTS TreeControl(
+	  TreeId                  BIGINT NOT NULL,
+	  SigningEnabled          BOOLEAN NOT NULL,
+	  SequencingEnabled       BOOLEAN NOT NULL,
+	  SequenceIntervalSeconds INTEGER NOT NULL,
+	  PRIMARY KEY(TreeId),
+	  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
+	);
+`
+
+	createTableSubtree = `
+CREATE TABLE IF NOT EXISTS Subtree(
+	  TreeId               BIGINT NOT NULL,
+	  SubtreeId            VARBINARY(255) NOT NULL,
+	  Nodes                MEDIUMBLOB NOT NULL,
+	  SubtreeRevision      INTEGER NOT NULL,
+	  -- Key columns must be in ASC order in order to benefit from group-by/min-max
+	  -- optimization in MySQL.
+	  PRIMARY KEY(TreeId, SubtreeId, SubtreeRevision),
+	  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
+	);
+`
+
+	createTableTreeHead = `
+CREATE TABLE IF NOT EXISTS TreeHead(
+	  TreeId               BIGINT NOT NULL,
+	  TreeHeadTimestamp    BIGINT,
+	  TreeSize             BIGINT,
+	  RootHash             VARBINARY(255) NOT NULL,
+	  RootSignature        VARBINARY(1024) NOT NULL,
+	  TreeRevision         BIGINT,
+	  PRIMARY KEY(TreeId, TreeHeadTimestamp),
+	  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
+	);
+`
+
+	createIndexTreeHeadRevision = `
+	CREATE UNIQUE INDEX TreeHeadRevisionIdx
+	  ON TreeHead(TreeId, TreeRevision);
+`
+
+	createTableLeafData = `
+	CREATE TABLE IF NOT EXISTS LeafData(
+	  TreeId               BIGINT NOT NULL,
+	  -- This is a personality specific has of some subset of the leaf data.
+	  -- It's only purpose is to allow Trillian to identify duplicate entries in
+	  -- the context of the personality.
+	  LeafIdentityHash     VARBINARY(255) NOT NULL,
+	  -- This is the data stored in the leaf for example in CT it contains a DER encoded
+	  -- X.509 certificate but is application dependent
+	  LeafValue            LONGBLOB NOT NULL,
+	  -- This is extra data that the application can associate with the leaf should it wish to.
+	  -- This data is not included in signing and hashing.
+	  ExtraData            LONGBLOB,
+	  -- The timestamp from when this leaf data was first queued for inclusion.
+	  QueueTimestampNanos  BIGINT NOT NULL,
+	  PRIMARY KEY(TreeId, LeafIdentityHash),
+	  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
+	);
+`
+
+	createTableSequencedLeafData = `
+CREATE TABLE IF NOT EXISTS SequencedLeafData(
+	  TreeId               BIGINT NOT NULL,
+	  SequenceNumber       BIGINT UNSIGNED NOT NULL,
+	  -- This is a personality specific has of some subset of the leaf data.
+	  -- It's only purpose is to allow Trillian to identify duplicate entries in
+	  -- the context of the personality.
+	  LeafIdentityHash     VARBINARY(255) NOT NULL,
+	  -- This is a MerkleLeafHash as defined by the treehasher that the log uses. For example for
+	  -- CT this hash will include the leaf prefix byte as well as the leaf data.
+	  MerkleLeafHash       VARBINARY(255) NOT NULL,
+	  IntegrateTimestampNanos BIGINT NOT NULL,
+	  PRIMARY KEY(TreeId, SequenceNumber),
+	  FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE,
+	  FOREIGN KEY(TreeId, LeafIdentityHash) REFERENCES LeafData(TreeId, LeafIdentityHash) ON DELETE CASCADE
+	);
+`
+
+	createIndexSequencedLeafMerkle = `
+	CREATE INDEX SequencedLeafMerkleIdx
+	  ON SequencedLeafData(TreeId, MerkleLeafHash);
+`
+
+	createTableUnsequenced = `
+	CREATE TABLE IF NOT EXISTS Unsequenced(
+	  TreeId               BIGINT NOT NULL,
+	  -- The bucket field is to allow the use of time based ring bucketed schemes if desired. If
+	  -- unused this should be set to zero for all entries.
+	  Bucket               INTEGER NOT NULL,
+	  -- This is a personality specific hash of some subset of the leaf data.
+	  -- It's only purpose is to allow Trillian to identify duplicate entries in
+	  -- the context of the personality.
+	  LeafIdentityHash     VARBINARY(255) NOT NULL,
+	  -- This is a MerkleLeafHash as defined by the treehasher that the log uses. For example for
+	  -- CT this hash will include the leaf prefix byte as well as the leaf data.
+	  MerkleLeafHash       VARBINARY(255) NOT NULL,
+	  QueueTimestampNanos  BIGINT NOT NULL,
+	  -- This is a SHA256 hash of the TreeID, LeafIdentityHash and QueueTimestampNanos. It is used
+	  -- for batched deletes from the table when trillian_log_server and trillian_log_signer are
+	  -- built with the batched_queue tag.
+	  QueueID VARBINARY(32) DEFAULT NULL UNIQUE,
+	  PRIMARY KEY (TreeId, Bucket, QueueTimestampNanos, LeafIdentityHash)
+	);
+`
+)
+
+// We need to create the tables in certain order because other tables
+// depend on others, so we list the order here and can't just yolo the
+// createTables map.
+var tables = []string{
+	"Trees",
+	"TreeControl",
+	"Subtree",
+	"TreeHead",
+	"LeafData",
+	"SequencedLeafData",
+	"Unsequenced",
+}
+
+// Map from table name to a statement that creates the table.
+var createTables = map[string]string{
+	"Trees":             createTableTrees,
+	"TreeControl":       createTableTreeControl,
+	"Subtree":           createTableSubtree,
+	"TreeHead":          createTableTreeHead,
+	"LeafData":          createTableLeafData,
+	"SequencedLeafData": createTableSequencedLeafData,
+	"Unsequenced":       createTableUnsequenced,
+}
+
+type indexCreate struct {
+	tableName string
+	createStr string
+}
+
+// Map from index name to table that should have it, which has statement
+// to create the index if it's missing.
+var createIndices = map[string]indexCreate{
+	"TreeHeadRevisionIdx":    {"TreeHead", createIndexTreeHeadRevision},
+	"SequencedLeafMerkleIdx": {"SequencedLeafData", createIndexSequencedLeafMerkle},
+}
+
+type envConfig struct {
+	DatabaseName string `envconfig:"DATABASE" default:"trillian" required:"true"`
+	ExitDir      string `envconfig:"EXIT_DIR" required:"false"`
+}
+
+var (
+	dbName   = flag.String("db_name", "trillian", "Database name to tack on to the connection string to select the right db.")
+	mysqlURI = flag.String("mysql_uri", "", "SQL connection string in mysql format, for example: $(USER):$(PWD)@tcp($(HOST):3306)/$(DATABASE_NAME)")
+)
+
+func main() {
+	flag.Parse()
+	if *mysqlURI == "" {
+		log.Panicf("Need to specify mysql_uri to know where to connect to")
+	}
+	if *dbName == "" {
+		log.Panicf("Need to specify database name")
+	}
+	connStr := fmt.Sprintf("%s/%s", strings.TrimSuffix(*mysqlURI, "/"), *dbName)
+	ctx := signals.NewContext()
+	db, err := sql.Open("mysql", connStr)
+	if err != nil {
+		log.Panicf("failed to open db connection: %v", err)
+	}
+	defer db.Close()
+	for i := 0; i < 5; i++ {
+		if err := db.Ping(); err == nil {
+			logging.FromContext(ctx).Infof("Ping to DB succeeded")
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if err := db.Ping(); err != nil {
+		log.Panicf("failed to ping db: %v", err)
+	}
+	// Grab the tables
+	existingTables := map[string]bool{}
+	tableRows, err := db.Query("show tables")
+	if err != nil {
+		logging.FromContext(ctx).Panicf("show tables failed: %+v", err)
+	}
+	defer tableRows.Close()
+	for next := tableRows.Next(); next; next = tableRows.Next() {
+		var tableName string
+		err = tableRows.Scan(&tableName)
+		if err != nil {
+			logging.FromContext(ctx).Errorf("Failed to get row %+v", err)
+		}
+		existingTables[tableName] = true
+	}
+
+	// Check the tables for existence and if they don't exist, create them.
+	for _, table := range tables {
+		if existingTables[table] {
+			logging.FromContext(ctx).Infof("Table %q exists", table)
+			continue
+		}
+		logging.FromContext(ctx).Infof("Table %q does not exist, creating", table)
+		if _, err = db.Exec(createTables[table]); err != nil {
+			logging.FromContext(ctx).Errorf("Failed to create table %q: %v", table, err)
+		} else {
+			logging.FromContext(ctx).Errorf("Created table %q", table)
+		}
+	}
+
+	for indexName, tableAndCreate := range createIndices {
+		tableName := tableAndCreate.tableName
+		indexExists, err := indexExists(ctx, db, *dbName, indexName, tableName)
+		if err != nil {
+			logging.FromContext(ctx).Panicf("Failed to check %q on %q for existence", indexName, tableName)
+		}
+		if indexExists {
+			logging.FromContext(ctx).Infof("Index %q exists on %q", indexName, tableName)
+			continue
+		}
+		logging.FromContext(ctx).Infof("Index %q does not exist on %q, creating", indexName, tableName)
+		if _, err = db.Exec(tableAndCreate.createStr); err != nil {
+			logging.FromContext(ctx).Errorf("Failed to create index %q on %q: %v", indexName, tableName, err)
+		} else {
+			logging.FromContext(ctx).Errorf("Created index %q on table %q", indexName, tableName)
+		}
+	}
+}
+
+func indexExists(ctx context.Context, db *sql.DB, dbName, indexName, table string) (bool, error) {
+	tableRows, err := db.Query(indexCheck, dbName, table, indexName)
+	if err != nil {
+		logging.FromContext(ctx).Panicf("checking for index failed: %+v", err)
+		return false, err
+	}
+	defer tableRows.Close()
+	var indexCount int64
+	for next := tableRows.Next(); next; next = tableRows.Next() {
+		err = tableRows.Scan(&indexCount)
+		if err != nil {
+			logging.FromContext(ctx).Errorf("Failed to get row %+v", err)
+		}
+		logging.FromContext(ctx).Infof("Found index %q on table %q : %+v", indexName, table, indexCount)
+	}
+	return indexCount > 0, nil
+}

--- a/config/trillian/createdb/100-namespace.yaml
+++ b/config/trillian/createdb/100-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: trillian-system

--- a/config/trillian/createdb/101-secret.yaml
+++ b/config/trillian/createdb/101-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trillian-client
+  namespace: trillian-system
+type: kubernetes.io/basic-auth
+stringData:
+  host: mysql-trillian.trillian-system.svc
+  name: trillian
+  username: trillian
+  password: trillian

--- a/config/trillian/createdb/101-service-account.yaml
+++ b/config/trillian/createdb/101-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: createdb
+  namespace: trillian-system

--- a/config/trillian/createdb/300-createdb.yaml
+++ b/config/trillian/createdb/300-createdb.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: createdb
+  namespace: trillian-system
+spec:
+  template:
+    spec:
+      serviceAccountName: createdb
+      restartPolicy: Never
+      containers:
+      - name: createdb
+        image: ko://github.com/sigstore/scaffolding/cmd/trillian/createdb
+        args: [
+        "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(DATABASE_HOSTNAME):3306)/",
+        "--db_name=trillian"
+        ]
+        env:
+          - name: DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: trillian-client
+                key: name
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: trillian-client
+                key: username
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: trillian-client
+                key: password
+          - name: DATABASE_HOSTNAME
+            valueFrom:
+              secretKeyRef:
+                name: trillian-client
+                key: host

--- a/config/trillian/createdb/placeholder.go
+++ b/config/trillian/createdb/placeholder.go
@@ -1,0 +1,15 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package createdb

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/go-openapi/runtime v0.23.3
 	github.com/go-openapi/strfmt v0.21.2
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/certificate-transparency-go v1.1.2
 	github.com/google/trillian v1.4.0
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This is to support the use case of using GCP Cloud SQL.
The database schema needs to be applied to the target MySQL instance.
My plan is to update the Trillian Helm chart to optionally create this batch job.

@vaikas @cpanato please take a look.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
