### PR TITLE
Make enabling CA service with Fulcio optional

### DIFF
--- a/terraform/gcp/modules/fulcio/fulcio.tf
+++ b/terraform/gcp/modules/fulcio/fulcio.tf
@@ -18,6 +18,9 @@
 module "ca" {
   source = "../ca"
 
+  # Disable CA creation if enable_ca is false
+  count = var.enable_ca ? 1 : 0
+
   region       = var.region
   project_id   = var.project_id
   ca_pool_name = var.ca_pool_name

--- a/terraform/gcp/modules/fulcio/variables.tf
+++ b/terraform/gcp/modules/fulcio/variables.tf
@@ -38,3 +38,9 @@ variable "ca_pool_name" {
   description = "Certificate authority pool name"
   type        = string
 }
+
+variable "enable_ca" {
+  description = "Enable a certificate authority via GCP CA Service"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Some clients may provide their own cert or not want to use GCP CA service. By default it will be enabled, but clients have the option to turn it off now.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
