### PR TITLE
change default cert registration info.

### DIFF
--- a/cmd/fulcio/createcerts/main.go
+++ b/cmd/fulcio/createcerts/main.go
@@ -44,7 +44,13 @@ const (
 )
 
 var (
-	secretName = flag.String("secret", "fulcio-secrets", "Name of the secret to create for the certs")
+	secretName   = flag.String("secret", "fulcio-secrets", "Name of the secret to create for the certs")
+	certOrg      = flag.String("cert-organization", "Linux Foundation", "Name of the organization for certificate creation")
+	certCountry  = flag.String("cert-country", "USA", "Name of the country for certificate creation")
+	certProvince = flag.String("cert-province", "California", "Name of the province for certificate creation")
+	certLocality = flag.String("cert-locality", "San Francisco", "Name of the locality for certificate creation")
+	certAddr     = flag.String("cert-address", "548 Market St", "Name of the address for certificate creation")
+	certPostal   = flag.String("cert-postal", "57274", "Name of the postal code for certificate creation")
 )
 
 func main() {
@@ -136,12 +142,12 @@ func createAll() ([]byte, []byte, []byte, string, error) {
 	rootCA := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			Organization:  []string{"chainguard"},
-			Country:       []string{"USA"},
-			Province:      []string{"WA"},
-			Locality:      []string{"Kirkland"},
-			StreetAddress: []string{"767 6th St S"},
-			PostalCode:    []string{"98033"},
+			Organization:  []string{*certOrg},
+			Country:       []string{*certCountry},
+			Province:      []string{*certProvince},
+			Locality:      []string{*certLocality},
+			StreetAddress: []string{*certAddr},
+			PostalCode:    []string{*certPostal},
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(1, 0, 0),


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Make certificate registration information configurable by flag.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
