### PR TITLE
pin versions using git commit instead of tags

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,21 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
     - cron: '32 8 * * 2'
@@ -33,27 +21,19 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@935969c6f771d9f0a35efa2ae9cf7c10d9886ca3 # v2.1.8
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@935969c6f771d9f0a35efa2ae9cf7c10d9886ca3 # v2.1.8
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +47,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@935969c6f771d9f0a35efa2ae9cf7c10d9886ca3 # v2.1.8

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -69,21 +69,21 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3.0.0
       with:
         go-version: 1.17.x
 
-    - uses: imjasonh/setup-ko@v0.4
+    - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
       with:
         version: tip
 
     - name: Check out our repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
       with:
         path: ./src/github.com/sigstore/scaffolding
 
     - name: Check out cosign repo so we get the head of the main cosign
-      uses: actions/checkout@v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
       with:
         repository: sigstore/cosign
         path: ./src/github.com/sigstore/cosign

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       COSIGN_EXPERIMENTAL: "true"
 
     steps:
-    - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
+    - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3.0.0
       with:
         go-version: 1.17.x
     # will use the latest release available for ko
@@ -28,7 +28,7 @@ jobs:
       uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
 
     - name: Install cosign
-      uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.1.0
+      uses: sigstore/cosign-installer@d6a3abf1bdea83574e28d40543793018b6035605 # v2.2.0
 
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2.9.1
@@ -36,7 +36,7 @@ jobs:
         install-only: true
 
     - name: Log into ghcr.io
-      uses: docker/login-action@v1
+      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
       - name: tfsec
-        uses: tfsec/tfsec-sarif-action@868eade2142739cee2153c9ceff9eba4beded067 # v0.0.6
+        uses: tfsec/tfsec-sarif-action@56bc584a8377626a31e511056772298ccfa69501 # v0.1.0
         with:
           sarif_file: tfsec.sarif
           working_directory: '.'

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout the current action
-      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
     - name: Test running the action
       uses: ./actions/setup
       with:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -118,7 +118,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
       with:
         name: logs
         path: /tmp/logs

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,8 +14,8 @@ jobs:
     name: license boilerplate check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v2.4.0
-      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Install addlicense
@@ -29,6 +29,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v2.4.0
+    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9 # v1.1.0


### PR DESCRIPTION
#### Summary
- pin versions using git commit instead of tags
also to make consistent across all projects in the org

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
