### PR TITLE
fix missing variables for kms rekor/fulcio

### DIFF
--- a/terraform/gcp/modules/rekor/rekor.tf
+++ b/terraform/gcp/modules/rekor/rekor.tf
@@ -22,9 +22,11 @@ module "kms" {
   project_id   = var.project_id
   cluster_name = var.cluster_name
 
-  name     = var.kms_keyring
-  location = var.kms_location
-  key_name = var.kms_key_name
+  fulcio_keyring_name = var.fulcio_keyring_name
+  rekor_keyring_name  = var.rekor_keyring_name
+  fulcio_key_name     = var.fulcio_key_name
+  rekor_key_name      = var.rekor_key_name
+  location            = var.kms_location
 }
 
 // Redis for Rekor.

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -46,9 +46,24 @@ variable "attestation_bucket" {
 
 
 // KMS
-variable "kms_keyring" {
+variable "rekor_keyring_name" {
   type        = string
-  description = "Name of KMS keyring"
+  description = "Name of KMS keyring for Rekor"
+}
+
+variable "fulcio_keyring_name" {
+  type        = string
+  description = "Name of KMS keyring for Fulcio"
+}
+
+variable "rekor_key_name" {
+  type        = string
+  description = "Name of KMS key for Rekor"
+}
+
+variable "fulcio_key_name" {
+  type        = string
+  description = "Name of KMS key for Fulcio"
 }
 
 variable "kms_location" {
@@ -56,7 +71,3 @@ variable "kms_location" {
   description = "Location of KMS keyring"
 }
 
-variable "kms_key_name" {
-  type        = string
-  description = "Name of KMS key for Rekor"
-}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -158,9 +158,11 @@ module "rekor" {
   network = module.network.network_self_link
 
   // KMS
-  kms_keyring  = "rekor-keyring"
-  kms_location = "global"
-  kms_key_name = "rekor-key"
+  rekor_keyring_name  = "rekor-keyring"
+  rekor_key_name      = "rekor-key"
+  fulcio_keyring_name = "fulcio-keyring"
+  fulcio_key_name     = "fulcio-key"
+  kms_location        = "global"
 
   // Storage
   attestation_bucket = var.attestation_bucket


### PR DESCRIPTION
#### Summary
- fix missing variables for kms rekor/fulcio

got this error when trying to plan for the sigstore staging

```shell
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/sigstore/terraform/gcp/modules/rekor/rekor.tf line 25, in module "kms":
│   25:   name     = var.kms_keyring
│ 
│ An argument named "name" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/sigstore/terraform/gcp/modules/rekor/rekor.tf line 27, in module "kms":
│   27:   key_name = var.kms_key_name
│ 
│ An argument named "key_name" is not expected here.
╵
Error: Process completed with exit code 1.
```

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
