### PR TITLE
Add checks in setup-kind for existing steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ imagerefs
 testimagerefs
 release.yaml
 testrelease.yaml
+kind.yaml


### PR DESCRIPTION
#### Summary
This PR fixes up some issue with running `hack/setup-kind.sh` multiple times.

#### Ticket Link

Fixes #64 

#### Release Note

```release-note
Fixes issues with setup-kind.sh on subsequent runs
```
