### PR TITLE
Add firewall to allow ingress webhook

### DIFF
--- a/config/fulcio/fulcio/300-fulcio.yaml
+++ b/config/fulcio/fulcio/300-fulcio.yaml
@@ -12,6 +12,9 @@ metadata:
   name: fulcio
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       serviceAccountName: fulcio
       # This doesn't actually use Kubernetes credentials, so don't mount them in.

--- a/config/rekor/rekor/300-rekor.yaml
+++ b/config/rekor/rekor/300-rekor.yaml
@@ -12,6 +12,9 @@ metadata:
   name: rekor
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       serviceAccountName: rekor
       containers:

--- a/terraform/gcp/modules/gke_cluster/node_pool.tf
+++ b/terraform/gcp/modules/gke_cluster/node_pool.tf
@@ -57,6 +57,7 @@ resource "google_container_node_pool" "cluster_nodes" {
     metadata = {
       disable-legacy-endpoints = true
     }
+    tags = [local.cluster_network_tag]
     shielded_instance_config {
       enable_secure_boot = var.enable_secure_boot
     }

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -128,6 +128,11 @@ variable "network_policy_provider" {
   default = "PROVIDER_UNSPECIFIED"
 }
 
+variable "cluster_network_tag" {
+  type    = string
+  default = ""
+}
+
 variable "cluster_autoscaling_profile" {
   type    = string
   default = "BALANCED"

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -104,6 +104,7 @@ module "gke-cluster" {
   subnetwork                    = module.network.subnetwork_self_link
   cluster_secondary_range_name  = module.network.secondary_ip_range.0.range_name
   services_secondary_range_name = module.network.secondary_ip_range.1.range_name
+  cluster_network_tag           = var.cluster_network_tag
 
   bastion_ip_address = module.bastion.ip_address
 

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -68,6 +68,11 @@ variable "cluster_name" {
   default     = "sigstore-staging"
 }
 
+variable "cluster_network_tag" {
+  type    = string
+  default = ""
+}
+
 variable "tunnel_accessor_sa" {
   type        = string
   description = "Email of group to give access to the tunnel to"


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Due to private GKE clusters only allowing the default ports of 80 and
443 to the workers, a separate firewall is needed to allow access to
port 8443 common for webhooks.

https://github.com/kubernetes/kubernetes/issues/79739
https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/v20.0.0/modules/private-cluster/firewall.tf#L60

add cluster_network_tag for firewall configuration.

@nsmith5 @cpanato @priyawadhwa PTAL

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
