### PR TITLE
have always 1 pod running to avoid scale to 0 in ci

### DIFF
--- a/testdata/config/gettoken/gettoken.yaml
+++ b/testdata/config/gettoken/gettoken.yaml
@@ -4,6 +4,10 @@ metadata:
   name: gettoken
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/initial-scale: "1"
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
       - name: gettoken


### PR DESCRIPTION

#### Summary
- have always 1 pod running to avoid scale to 0 in ci

#### Ticket Link

Fixes: https://github.com/sigstore/scaffolding/issues/128

#### Release Note

```release-note
NONE
```
