### PR TITLE
More uptime alerts for rekor endpoints

### DIFF
--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -14,49 +14,11 @@
  * limitations under the License.
  */
 
-# Alert for Rekor uptime
-resource "google_monitoring_alert_policy" "rekor_uptime_alert" {
-  # In the absence of data, incident will auto-close in 7 days
-  alert_strategy {
-    auto_close = "604800s"
-  }
-  combiner = "OR"
-
-  conditions {
-    condition_threshold {
-      aggregations {
-        alignment_period     = "1200s"
-        cross_series_reducer = "REDUCE_COUNT_FALSE"
-        group_by_fields      = ["resource.*"]
-        per_series_aligner   = "ALIGN_NEXT_OLDER"
-      }
-
-      comparison = "COMPARISON_GT"
-      duration   = "60s"
-      filter     = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_rekor.uptime_check_id)
-
-      threshold_value = "1"
-
-      trigger {
-        count   = "1"
-        percent = "0"
-      }
-    }
-
-    display_name = "Failure of uptime check_id rekor-uptime"
-  }
-
-  display_name          = "Rekor uptime alert"
-  enabled               = "true"
-  notification_channels = local.notification_channels
-  project               = var.project_id
-  depends_on            = [google_monitoring_uptime_check_config.uptime_rekor]
-}
-
-# Alert for Rekor uptime
+# Alert for Rekor uptime: GET
 resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
   for_each = toset([
     // API endpoints we want to test
+    "",
     "/api/v1/version",
     "/api/v1/index/retrieve",
     "/api/v1/log",
@@ -122,7 +84,7 @@ resource "google_monitoring_alert_policy" "rekor_api_latency_alert" {
 
       comparison = "COMPARISON_GT"
       duration   = "0s"
-      filter     = format("metric.type=\"monitoring.googleapis.com/uptime_check/request_latency\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_rekor.uptime_check_id)
+      filter     = format("metric.type=\"monitoring.googleapis.com/uptime_check/request_latency\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.rekor_uptime_alerts[""].uptime_check_id)
 
       threshold_value = "750"
 
@@ -145,6 +107,6 @@ resource "google_monitoring_alert_policy" "rekor_api_latency_alert" {
   enabled               = "true"
   notification_channels = local.notification_channels
   project               = var.project_id
-  depends_on            = [google_monitoring_alert_policy.rekor_uptime_alert]
+  depends_on            = [google_monitoring_alert_policy.rekor_uptime_alerts]
 }
 

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -16,17 +16,7 @@
 
 # Alert for Rekor uptime: GET
 resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
-  for_each = toset([
-    // API endpoints we want to test
-    "",
-    "/api/v1/version",
-    "/api/v1/index/retrieve",
-    "/api/v1/log",
-    "/api/v1/log/publicKey",
-    "/api/v1/log/proof",
-    "/api/v1/log/entries",
-    "/api/v1/log/entries/retrieve"
-  ])
+  for_each = toset(var.api_endpoints_get)
 
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {

--- a/terraform/gcp/modules/monitoring/rekor/uptime.tf
+++ b/terraform/gcp/modules/monitoring/rekor/uptime.tf
@@ -19,6 +19,7 @@
 resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts" {
   for_each = toset([
     // API endpoints we want to test
+    "",
     "/api/v1/version",
     "/api/v1/index/retrieve",
     "/api/v1/log",
@@ -53,28 +54,3 @@ resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts" {
   timeout = "10s"
 }
 
-resource "google_monitoring_uptime_check_config" "uptime_rekor" {
-  display_name = "Rekor uptime"
-
-  http_check {
-    mask_headers   = "false"
-    path           = "/"
-    port           = "443"
-    request_method = "GET"
-    use_ssl        = "true"
-    validate_ssl   = "true"
-  }
-
-  monitored_resource {
-    labels = {
-      host       = var.rekor_url
-      project_id = var.project_id
-    }
-
-    type = "uptime_url"
-  }
-
-  period  = "60s"
-  project = var.project_id
-  timeout = "10s"
-}

--- a/terraform/gcp/modules/monitoring/rekor/uptime.tf
+++ b/terraform/gcp/modules/monitoring/rekor/uptime.tf
@@ -14,6 +14,45 @@
  * limitations under the License.
  */
 
+
+// Enable required services for this module
+resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts" {
+  for_each = toset([
+    // API endpoints we want to test
+    "/api/v1/version",
+    "/api/v1/index/retrieve",
+    "/api/v1/log",
+    "/api/v1/log/publicKey",
+    "/api/v1/log/proof",
+    "/api/v1/log/entries",
+    "/api/v1/log/entries/retrieve"
+  ])
+
+  display_name = format("Rekor uptime - %s", each.key)
+
+  http_check {
+    mask_headers   = "false"
+    path           = each.key
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.rekor_url
+      project_id = var.project_id
+    }
+
+    type = "uptime_url"
+  }
+
+  period  = "60s"
+  project = var.project_id
+  timeout = "10s"
+}
+
 resource "google_monitoring_uptime_check_config" "uptime_rekor" {
   display_name = "Rekor uptime"
 

--- a/terraform/gcp/modules/monitoring/rekor/uptime.tf
+++ b/terraform/gcp/modules/monitoring/rekor/uptime.tf
@@ -17,17 +17,7 @@
 
 // Enable required services for this module
 resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts" {
-  for_each = toset([
-    // API endpoints we want to test
-    "",
-    "/api/v1/version",
-    "/api/v1/index/retrieve",
-    "/api/v1/log",
-    "/api/v1/log/publicKey",
-    "/api/v1/log/proof",
-    "/api/v1/log/entries",
-    "/api/v1/log/entries/retrieve"
-  ])
+  for_each = toset(var.api_endpoints_get)
 
   display_name = format("Rekor uptime - %s", each.key)
 

--- a/terraform/gcp/modules/monitoring/rekor/uptime.tf
+++ b/terraform/gcp/modules/monitoring/rekor/uptime.tf
@@ -16,7 +16,7 @@
 
 
 // Enable required services for this module
-resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts" {
+resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts_get" {
   for_each = toset(var.api_endpoints_get)
 
   display_name = format("Rekor uptime - %s", each.key)
@@ -43,4 +43,3 @@ resource "google_monitoring_uptime_check_config" "rekor_uptime_alerts" {
   project = var.project_id
   timeout = "10s"
 }
-

--- a/terraform/gcp/modules/monitoring/rekor/variables.tf
+++ b/terraform/gcp/modules/monitoring/rekor/variables.tf
@@ -37,14 +37,11 @@ variable "notification_channel_id" {
 
 variable "api_endpoints_get" {
   type = list(string)
-  default = ["",
+  default = [
+    "/",
     "/api/v1/version",
-    "/api/v1/index/retrieve",
     "/api/v1/log",
     "/api/v1/log/publicKey",
-    "/api/v1/log/proof",
-    "/api/v1/log/entries",
-    "/api/v1/log/entries/retrieve"
   ]
 }
 

--- a/terraform/gcp/modules/monitoring/rekor/variables.tf
+++ b/terraform/gcp/modules/monitoring/rekor/variables.tf
@@ -35,6 +35,19 @@ variable "notification_channel_id" {
   description = "The notification channel ID which alerts should be sent to. You can find this by running `gcloud alpha monitoring channels list`."
 }
 
+variable "api_endpoints_get" {
+  type = list(string)
+  default = ["",
+    "/api/v1/version",
+    "/api/v1/index/retrieve",
+    "/api/v1/log",
+    "/api/v1/log/publicKey",
+    "/api/v1/log/proof",
+    "/api/v1/log/entries",
+    "/api/v1/log/entries/retrieve"
+  ]
+}
+
 locals {
   notification_channels = [format("projects/%v/notificationChannels/%v", var.project_id, var.notification_channel_id)]
 }


### PR DESCRIPTION
Adding in some more uptime checks and latency/uptime alerts for Rekor API endpoints. This will help us guarantee our SLO.