### PR TITLE
Make mysql instance name, and keys configurable in Terraform

### DIFF
--- a/terraform/gcp/modules/ca/ca.tf
+++ b/terraform/gcp/modules/ca/ca.tf
@@ -92,7 +92,7 @@ resource "google_privateca_ca_pool" "sigstore-ca-pool" {
 }
 
 resource "google_privateca_certificate_authority" "sigstore-ca" {
-  certificate_authority_id = "sigstore-authority"
+  certificate_authority_id = var.ca_name
   location                 = var.region
   project                  = var.project_id
   pool                     = google_privateca_ca_pool.sigstore-ca-pool.name

--- a/terraform/gcp/modules/ca/variables.tf
+++ b/terraform/gcp/modules/ca/variables.tf
@@ -34,3 +34,10 @@ variable "ca_pool_name" {
   type        = string
   default     = "sigstore"
 }
+
+variable "ca_name" {
+  description = "Certificate authority name"
+  type        = string
+  default     = "sigstore-authority"
+}
+

--- a/terraform/gcp/modules/fulcio/fulcio.tf
+++ b/terraform/gcp/modules/fulcio/fulcio.tf
@@ -24,4 +24,5 @@ module "ca" {
   region       = var.region
   project_id   = var.project_id
   ca_pool_name = var.ca_pool_name
+  ca_name      = var.ca_name
 }

--- a/terraform/gcp/modules/fulcio/variables.tf
+++ b/terraform/gcp/modules/fulcio/variables.tf
@@ -39,6 +39,12 @@ variable "ca_pool_name" {
   type        = string
 }
 
+variable "ca_name" {
+  description = "Certificate authority name"
+  type        = string
+  default     = "sigstore-authority"
+}
+
 variable "enable_ca" {
   description = "Enable a certificate authority via GCP CA Service"
   type        = bool

--- a/terraform/gcp/modules/mysql/mysql.tf
+++ b/terraform/gcp/modules/mysql/mysql.tf
@@ -90,7 +90,7 @@ resource "random_id" "db_name_suffix" {
 
 resource "google_sql_database_instance" "trillian" {
   project          = var.project_id
-  name             = format("%s-mysql-%s", var.cluster_name, random_id.db_name_suffix.hex)
+  name             = var.instance_name != "" ? var.instance_name : format("%s-mysql-%s", var.cluster_name, random_id.db_name_suffix.hex)
   database_version = "MYSQL_8_0"
   region           = var.region
 

--- a/terraform/gcp/modules/mysql/variables.tf
+++ b/terraform/gcp/modules/mysql/variables.tf
@@ -43,3 +43,10 @@ variable "subnetwork" {
   type    = string
   default = "default"
 }
+
+variable "instance_name" {
+  type        = string
+  description = "Name for MySQL instance. If unspecified, will default to '[var.cluster-name]-mysql-[random.suffix]'"
+  default     = ""
+}
+

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -125,6 +125,8 @@ module "mysql" {
 
   network = module.network.network_self_link
 
+  instance_name = var.mysql_instance_name
+
   depends_on = [
     module.network,
     module.gke-cluster
@@ -159,8 +161,8 @@ module "rekor" {
   network = module.network.network_self_link
 
   // KMS
-  rekor_keyring_name = "rekor-keyring"
-  rekor_key_name     = "rekor-key"
+  rekor_keyring_name = var.rekor_keyring_name
+  rekor_key_name     = var.rekor_key_name
   kms_location       = "global"
 
   // Storage
@@ -182,10 +184,11 @@ module "fulcio" {
 
   // Certificate authority
   ca_pool_name = var.ca_pool_name
+  ca_name      = var.ca_name
 
   // KMS
-  fulcio_keyring_name = "fulcio-keyring"
-  fulcio_key_name     = "fulcio-intermediate-key"
+  fulcio_keyring_name = var.fulcio_keyring_name
+  fulcio_key_name     = var.fulcio_intermediate_key_name
 
   depends_on = [
     module.gke-cluster,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -43,6 +43,12 @@ variable "ca_pool_name" {
   default     = "sigstore"
 }
 
+variable "ca_name" {
+  description = "Certificate authority name"
+  type        = string
+  default     = "sigstore-authority"
+}
+
 variable "monitoring" {
   description = "Monitoring and alerting"
   type = object({
@@ -81,4 +87,34 @@ variable "tunnel_accessor_sa" {
 variable "github_repo" {
   description = "Github repo for running Github Actions from."
   type        = string
+}
+
+variable "mysql_instance_name" {
+  type        = string
+  description = "Name for MySQL instance. If unspecified, will default to '[var.cluster-name]-mysql-[random.suffix]'"
+  default     = ""
+}
+
+variable "fulcio_keyring_name" {
+  type        = string
+  description = "Name of Fulcio keyring."
+  default     = "fulcio-keyring"
+}
+
+variable "fulcio_intermediate_key_name" {
+  type        = string
+  description = "Name of Fulcio intermediate key."
+  default     = "fulcio-intermediate-key"
+}
+
+variable "rekor_keyring_name" {
+  type        = string
+  description = "Name of Rekor keyring."
+  default     = "rekor-keyring"
+}
+
+variable "rekor_key_name" {
+  type        = string
+  description = "Name of Rekor key."
+  default     = "rekor-key"
 }


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

@priyawadhwa @cpanato 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
