### PR TITLE
Add in a read-only prober across Rekor and Fulcio API endpoints

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -90,3 +90,18 @@ builds:
   - -w
   - -extldflags "-static"
   - "{{ .Env.LDFLAGS }}"
+
+- id: prober
+  dir: .
+  main: ./cmd/prober
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - -tags
+  - nostackdriver
+  ldflags:
+  - -s
+  - -w
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"

--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 var (

--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -41,3 +41,10 @@ var RekorEndpoints = []ReadProberCheck{
 		body:     "{\"hash\":\"sha256:2bd37672a9e472c79c64f42b95e362db16870e28a90f3b17fee8faf952e79b4b\"}",
 	},
 }
+
+var FulcioEndpoints = []ReadProberCheck{
+	{
+		endpoint: "/api/v1/rootCert",
+		method:   GET,
+	},
+}

--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -1,0 +1,33 @@
+package main
+
+var (
+	GET  = "GET"
+	POST = "POST"
+)
+
+type ReadProberCheck struct {
+	endpoint string
+	method   string
+	body     string
+}
+
+/*
+/api/v1/index/retrieve
+/api/v1/log
+/api/v1/log/publicKey
+/api/v1/log/proof
+/api/v1/log/entries
+/api/v1/log/entries
+/api/v1/log/entries/retrieve
+*/
+
+var RekorEndpoints = []ReadProberCheck{
+	{
+		endpoint: "/api/v1/version",
+		method:   GET,
+	},
+	{
+		endpoint: "/api/v1/log/publicKey",
+		method:   GET,
+	},
+}

--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -9,25 +9,35 @@ type ReadProberCheck struct {
 	endpoint string
 	method   string
 	body     string
+	queries  map[string]string
 }
-
-/*
-/api/v1/index/retrieve
-/api/v1/log
-/api/v1/log/publicKey
-/api/v1/log/proof
-/api/v1/log/entries
-/api/v1/log/entries
-/api/v1/log/entries/retrieve
-*/
 
 var RekorEndpoints = []ReadProberCheck{
 	{
 		endpoint: "/api/v1/version",
 		method:   GET,
-	},
-	{
+	}, {
 		endpoint: "/api/v1/log/publicKey",
 		method:   GET,
+	},
+	{
+		endpoint: "/api/v1/log",
+		method:   GET,
+	}, {
+		endpoint: "/api/v1/log/entries",
+		method:   GET,
+		queries:  map[string]string{"logIndex": "10"},
+	}, {
+		endpoint: "/api/v1/log/proof",
+		method:   GET,
+		queries:  map[string]string{"firstSize": "10", "lastSize": "20"},
+	}, {
+		endpoint: "/api/v1/log/entries/retrieve",
+		method:   POST,
+		body:     "{\"hash\":\"sha256:2bd37672a9e472c79c64f42b95e362db16870e28a90f3b17fee8faf952e79b4b\"}",
+	}, {
+		endpoint: "/api/v1/index/retrieve",
+		method:   POST,
+		body:     "{\"hash\":\"sha256:2bd37672a9e472c79c64f42b95e362db16870e28a90f3b17fee8faf952e79b4b\"}",
 	},
 }

--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -87,6 +101,7 @@ func observeRequest(host string, r ReadProberCheck) error {
 		hostLabel:       host,
 	}
 	fmt.Println("Status code: ", resp.StatusCode)
+	fmt.Println("Latency: ", latency)
 	endpointLatenciesHistogram.With(labels).Observe(float64(latency))
 	endpointLatenciesSummary.With(labels).Observe(float64(latency))
 	return nil

--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	frequency int
+	addr      string
+	rekorURL  string
+	fulcioURL string
+)
+
+func init() {
+	flag.IntVar(&frequency, "frequecy", 10, "How often to run probers (in seconds)")
+	flag.StringVar(&addr, "addr", ":8080", "Port to expose prometheus to")
+
+	flag.StringVar(&rekorURL, "rekor-url", "https://rekor.sigstore.dev", "Set to the Rekor URL to run probers against")
+	flag.StringVar(&fulcioURL, "fulcio-url", "https://fulcio.sigstore.dev", "Set to the Fulcio URL to run probers against")
+
+	flag.Parse()
+}
+
+func main() {
+	go runProbers()
+
+	prometheus.MustRegister(endpointLatencies)
+
+	// Expose the registered metrics via HTTP.
+	http.Handle("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			// Opt into OpenMetrics to support exemplars.
+			EnableOpenMetrics: true,
+		},
+	))
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func runProbers() {
+	for {
+		for _, r := range RekorEndpoints {
+			if err := runRequest(rekorURL, r); err != nil {
+				fmt.Printf("error running request %s: %v\n", r.endpoint, err)
+			}
+		}
+		time.Sleep(time.Duration(frequency) * time.Second)
+	}
+}
+
+func runRequest(host string, r ReadProberCheck) error {
+	client := &http.Client{}
+
+	s := time.Now()
+	req, err := http.NewRequest(r.method, host+r.endpoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	latency := time.Since(s).Milliseconds()
+
+	endpointLatencies.WithLabelValues(r.endpoint).Observe(float64(latency))
+
+	fmt.Println("latency:", latency)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		bytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(bytes))
+	}
+	return nil
+}

--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -53,6 +53,11 @@ func runProbers() {
 				fmt.Printf("error running request %s: %v\n", r.endpoint, err)
 			}
 		}
+		for _, r := range FulcioEndpoints {
+			if err := observeRequest(fulcioURL, r); err != nil {
+				fmt.Printf("error running request %s: %v\n", r.endpoint, err)
+			}
+		}
 		fmt.Println("Complete")
 		time.Sleep(time.Duration(frequency) * time.Second)
 	}

--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -30,14 +30,14 @@ func init() {
 }
 
 func main() {
-	prometheus.MustRegister(endpointLatenciesSummary)
-	prometheus.MustRegister(endpointLatenciesHistogram)
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(endpointLatenciesSummary, endpointLatenciesHistogram)
 
 	go runProbers()
 
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.HandlerFor(
-		prometheus.DefaultGatherer,
+		reg,
 		promhttp.HandlerOpts{
 			// Opt into OpenMetrics to support exemplars.
 			EnableOpenMetrics: true,

--- a/cmd/prober/prometheus.go
+++ b/cmd/prober/prometheus.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/cmd/prober/prometheus.go
+++ b/cmd/prober/prometheus.go
@@ -13,7 +13,7 @@ var (
 	endpointLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "api_endpoint_latency",
-			Help:       "API endpoint latency distributions.",
+			Help:       "API endpoint latency distributions (milliseconds).",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, .999: 0.0001},
 		},
 		[]string{endpointLabel, hostLabel, statusCodeLabel},

--- a/cmd/prober/prometheus.go
+++ b/cmd/prober/prometheus.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// Track latency for each endpoint
+	endpointLatencies = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "api_endpoint_latency",
+			Help:       "API endpoint latency distributions.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, .999: 0.0001},
+		},
+		[]string{"endpoint"},
+	)
+)

--- a/cmd/prober/prometheus.go
+++ b/cmd/prober/prometheus.go
@@ -3,13 +3,26 @@ package main
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
+	endpointLabel   = "endpoint"
+	hostLabel       = "host"
+	statusCodeLabel = "status_code"
+)
+
+var (
 	// Track latency for each endpoint
-	endpointLatencies = prometheus.NewSummaryVec(
+	endpointLatenciesSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "api_endpoint_latency",
 			Help:       "API endpoint latency distributions.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, .999: 0.0001},
 		},
-		[]string{"endpoint"},
+		[]string{endpointLabel, hostLabel, statusCodeLabel},
 	)
+
+	endpointLatenciesHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "api_endpoint_latency_histogram",
+		Help:    "API endpoint latency distribution across Rekor and Fulcio (milliseconds)",
+		Buckets: []float64{0.0, 200.0, 400.0, 600.0, 800.0, 1000.0},
+	},
+		[]string{endpointLabel, hostLabel, statusCodeLabel})
 )

--- a/config/prober/100-namspace.yaml
+++ b/config/prober/100-namspace.yaml
@@ -1,0 +1,5 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: sigstore-prober

--- a/config/prober/200-deployment.yaml
+++ b/config/prober/200-deployment.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: sigstore-prober
+  name: sigstore-prober
+  labels:
+    app: sigstore-prober
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sigstore-prober
+  template:
+    metadata:
+      labels:
+        app: sigstore-prober
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+      - name: sigstore-prober
+        image: ko://github.com/sigstore/scaffolding/cmd/prober
+        ports:
+        - containerPort: 8080 # metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: sigstore-prober
+  name: sigstore-prober
+spec:
+  selector:
+    app: sigstore-prober
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000

--- a/config/prober/200-deployment.yaml
+++ b/config/prober/200-deployment.yaml
@@ -25,17 +25,3 @@ spec:
         image: ko://github.com/sigstore/scaffolding/cmd/prober
         ports:
         - containerPort: 8080 # metrics
----
-apiVersion: v1
-kind: Service
-metadata:
-  namespace: sigstore-prober
-  name: sigstore-prober
-spec:
-  selector:
-    app: sigstore-prober
-  type: LoadBalancer
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 3000


### PR DESCRIPTION
This prober performs all read requests across endpoints and exports data from prometheus. we can run it in the staging and production clusters to track metrics and set alerts.