### PR TITLE
make storage class and location configurable.

### DIFF
--- a/terraform/gcp/modules/rekor/storage.tf
+++ b/terraform/gcp/modules/rekor/storage.tf
@@ -17,10 +17,10 @@
 // Attestation bucket and relevant IAM
 resource "google_storage_bucket" "attestation" {
   name     = var.attestation_bucket
-  location = var.region
+  location = var.attestation_region == "" ? var.region : var.attestation_region
   project  = var.project_id
 
-  storage_class               = "REGIONAL"
+  storage_class               = var.storage_class
   uniform_bucket_level_access = true
 
   versioning {

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -44,6 +44,17 @@ variable "attestation_bucket" {
   description = "Name of GCS bucket for attestation."
 }
 
+variable "attestation_region" {
+  type        = string
+  description = "Attestation bucket region"
+  default     = ""
+}
+
+variable "storage_class" {
+  type        = string
+  description = "Storage class for TUF root bucket."
+  default     = "REGIONAL"
+}
 
 // KMS
 variable "rekor_keyring_name" {

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -45,7 +45,8 @@ module "tuf" {
   region     = var.region
   project_id = var.project_id
 
-  tuf_bucket = var.tuf_bucket
+  tuf_bucket    = var.tuf_bucket
+  storage_class = var.tuf_storage_class
 }
 
 // Monitoring
@@ -168,6 +169,8 @@ module "rekor" {
 
   // Storage
   attestation_bucket = var.attestation_bucket
+  attestation_region = var.attestation_region == "" ? var.region : var.attestation_region
+  storage_class      = var.attestation_storage_class
 
   depends_on = [
     module.network,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -27,14 +27,38 @@ variable "region" {
   type        = string
 }
 
+variable "tuf_region" {
+  description = "The region in which to create the TUF bucket"
+  type        = string
+  default     = ""
+}
+
+variable "attestation_region" {
+  description = "The region in which to create the attestation bucket"
+  type        = string
+  default     = ""
+}
+
 variable "attestation_bucket" {
   type        = string
   description = "Name of GCS bucket for attestation."
 }
 
+variable "attestation_storage_class" {
+  type        = string
+  description = "Storage class for attestation bucket."
+  default     = "REGIONAL"
+}
+
 variable "tuf_bucket" {
   type        = string
   description = "Name of GCS bucket for TUF root."
+}
+
+variable "tuf_storage_class" {
+  type        = string
+  description = "Storage class for TUF bucket."
+  default     = "REGIONAL"
 }
 
 variable "ca_pool_name" {

--- a/terraform/gcp/modules/tuf/tuf.tf
+++ b/terraform/gcp/modules/tuf/tuf.tf
@@ -33,7 +33,7 @@ resource "google_storage_bucket" "tuf" {
   location = var.region
   project  = var.project_id
 
-  storage_class               = "REGIONAL"
+  storage_class               = var.storage_class
   uniform_bucket_level_access = true
 
   versioning {

--- a/terraform/gcp/modules/tuf/variables.tf
+++ b/terraform/gcp/modules/tuf/variables.tf
@@ -32,3 +32,9 @@ variable "tuf_bucket" {
   type        = string
   description = "Name of GCS bucket for TUF root."
 }
+
+variable "storage_class" {
+  type        = string
+  description = "Storage class for TUF root bucket."
+  default     = "REGIONAL"
+}


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
This is to allow importing existing tuf and attestation buckets. Recreating these buckets would require code coordination with cosign cli.

@priyawadhwa @cpanato 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
