### PR TITLE
Bind sigstore-prober KSA to GCP prometheus service account

### DIFF
--- a/terraform/gcp/modules/gke_cluster/service_accounts.tf
+++ b/terraform/gcp/modules/gke_cluster/service_accounts.tf
@@ -50,6 +50,13 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_prometheus" {
   depends_on         = [google_service_account.prometheus-sa, google_container_cluster.cluster]
 }
 
+resource "google_service_account_iam_member" "gke_sa_iam_member_prometheus_prober" {
+  service_account_id = google_service_account.prometheus-sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[sigstore-prober/sigstore-prober]"
+  depends_on         = [google_service_account.prometheus-sa, google_container_cluster.cluster]
+}
+
 resource "google_project_iam_member" "prometheus_member" {
   project    = var.project_id
   role       = "roles/monitoring.metricWriter"


### PR DESCRIPTION
This way the prober can export  metrics to GCP Cloud Monitoring.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
