### PR TITLE
Add vars for mysql to allow matching prod migration instance.

### DIFF
--- a/terraform/gcp/modules/mysql/mysql.tf
+++ b/terraform/gcp/modules/mysql/mysql.tf
@@ -97,14 +97,14 @@ resource "google_sql_database_instance" "trillian" {
   depends_on = [google_service_networking_connection.private_vpc_connection]
 
   settings {
-    tier              = "db-n1-standard-1"
+    tier              = var.tier
     activation_policy = "ALWAYS"
-    availability_type = "REGIONAL"
+    availability_type = var.availability_type
 
     ip_configuration {
-      ipv4_enabled    = "false"
+      ipv4_enabled    = var.ipv4_enabled
       private_network = var.network
-      require_ssl     = "true"
+      require_ssl     = var.require_ssl
     }
 
     database_flags {
@@ -113,8 +113,8 @@ resource "google_sql_database_instance" "trillian" {
     }
 
     backup_configuration {
-      enabled            = true
-      binary_log_enabled = true
+      enabled            = var.backup_enabled
+      binary_log_enabled = var.binary_log_backup_enabled
     }
   }
 

--- a/terraform/gcp/modules/mysql/variables.tf
+++ b/terraform/gcp/modules/mysql/variables.tf
@@ -34,6 +34,42 @@ variable "cluster_name" {
   default = ""
 }
 
+variable "tier" {
+  type        = string
+  description = "Machine tier for MySQL instance."
+  default     = "db-n1-standard-1"
+}
+
+variable "availability_type" {
+  type        = string
+  description = "Availability tier for MySQL"
+  default     = "REGIONAL"
+}
+
+variable "ipv4_enabled" {
+  type        = bool
+  description = "Whether to enable ipv4 for MySQL instance."
+  default     = false
+}
+
+variable "require_ssl" {
+  type        = bool
+  description = "Whether to require ssl for MySQL instance."
+  default     = true
+}
+
+variable "backup_enabled" {
+  type        = bool
+  description = "Whether to enable backup configuration."
+  default     = true
+}
+
+variable "binary_log_backup_enabled" {
+  type        = bool
+  description = "Whether to enable binary log for backup."
+  default     = true
+}
+
 variable "network" {
   type    = string
   default = "default"

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -122,12 +122,20 @@ module "mysql" {
   region     = var.region
   project_id = var.project_id
 
-  cluster_name = var.cluster_name
+  cluster_name      = var.cluster_name
+  tier              = var.mysql_tier
+  availability_type = var.mysql_availability_type
 
   network = module.network.network_self_link
 
   instance_name = var.mysql_instance_name
   db_name       = var.mysql_db_name
+
+  ipv4_enabled              = var.mysql_ipv4_enabled
+  require_ssl               = var.mysql_require_ssl
+  backup_enabled            = var.mysql_backup_enabled
+  binary_log_backup_enabled = var.mysql_binary_log_backup_enabled
+
 
   depends_on = [
     module.network,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -125,6 +125,44 @@ variable "mysql_db_name" {
   default     = "trillian"
 }
 
+variable "mysql_tier" {
+  type        = string
+  description = "Machine tier for MySQL instance."
+  default     = "db-n1-standard-1"
+}
+
+variable "mysql_availability_type" {
+  type        = string
+  description = "Availability tier for MySQL"
+  default     = "REGIONAL"
+}
+
+variable "mysql_ipv4_enabled" {
+  type        = bool
+  description = "Whether to enable ipv4 for MySQL instance."
+  default     = false
+}
+
+variable "mysql_require_ssl" {
+  type        = bool
+  description = "Whether to require ssl for MySQL instance."
+  default     = true
+}
+
+variable "mysql_backup_enabled" {
+  type        = bool
+  description = "Whether to enable backup configuration for MySQL instance."
+  default     = true
+}
+
+variable "mysql_binary_log_backup_enabled" {
+  type        = bool
+  description = "Whether to enable binary log for backup for MySQL instance."
+  default     = true
+}
+
+
+
 variable "fulcio_keyring_name" {
   type        = string
   description = "Name of Fulcio keyring."


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Since we are migrating the prod MySQL instance, the new instance is in
read-only mode as it mirrors the current prod instance.

To allow terraform to move forward without modifying the read-only
instance, temporarily configure the MySQL to match the settings.
These settings can be changed afterwards.

@priyawadhwa @cpanato 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
