### PR TITLE
Add in prober alerts for absent data and non-200 error codes

### DIFF
--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -97,3 +97,88 @@ resource "google_monitoring_alert_policy" "prober_fulcio_endpoint_latency" {
   notification_channels = local.notification_channels
   project               = var.project_id
 }
+
+resource "google_monitoring_alert_policy" "prober_data_absent_alert" {
+  for_each = toset(local.hosts)
+
+  alert_strategy {
+    auto_close = "604800s"
+  }
+
+  combiner = "OR"
+
+  conditions {
+    condition_absent {
+      aggregations {
+        alignment_period     = "300s"
+        cross_series_reducer = "REDUCE_PERCENTILE_95"
+        group_by_fields      = ["metric.label.endpoint"]
+        per_series_aligner   = "ALIGN_MEAN"
+      }
+
+      duration = "300s"
+      filter   = format("resource.type = \"k8s_container\" AND metric.type = \"external.googleapis.com/prometheus/api_endpoint_latency\" AND metric.labels.host = \"%s\"", each.key)
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = format("API Endpoint Latency Data Absent for 5 minutes: %s", each.key)
+  }
+
+  display_name = format("API Endpoint Latency Data Absent for 5 minutes: %s", each.key)
+
+  documentation {
+    content   = format("API Endpoint Latency Data Absent for 5 minutes: %s. Check playbook for more details.", each.key)
+    mime_type = "text/markdown"
+  }
+
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+}
+
+resource "google_monitoring_alert_policy" "prober_error_codes" {
+  alert_strategy {
+    auto_close = "604800s"
+  }
+
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period     = "300s"
+        cross_series_reducer = "REDUCE_COUNT"
+        group_by_fields      = ["metric.label.endpoint"]
+        per_series_aligner   = "ALIGN_MEAN"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "0s"
+      filter          = "resource.type = \"k8s_container\" AND metric.type = \"external.googleapis.com/prometheus/api_endpoint_latency\" AND metric.labels.status_code != \"200\""
+      threshold_value = "0"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Sigstore API Prober Error Codes"
+  }
+
+  display_name = "Sigstore API Prober Error Codes"
+
+  documentation {
+    content   = "At least one Sigstore API endpoint has returned non-200 error codes for at least 5 minutes.\n"
+    mime_type = "text/markdown"
+  }
+
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+}
+

--- a/terraform/gcp/modules/monitoring/prober/variables.tf
+++ b/terraform/gcp/modules/monitoring/prober/variables.tf
@@ -42,4 +42,5 @@ variable "notification_channel_id" {
 
 locals {
   notification_channels = [format("projects/%v/notificationChannels/%v", var.project_id, var.notification_channel_id)]
+  hosts                 = [var.rekor_url, var.fulcio_url]
 }

--- a/terraform/gcp/modules/monitoring/sigstore.tf
+++ b/terraform/gcp/modules/monitoring/sigstore.tf
@@ -72,6 +72,8 @@ module "prober" {
 
   project_id              = var.project_id
   notification_channel_id = var.notification_channel_id
+  rekor_url               = local.qualified_rekor_url
+  fulcio_url              = local.qualified_fulcio_url
 
   depends_on = [
     google_project_service.service

--- a/terraform/gcp/modules/monitoring/variables.tf
+++ b/terraform/gcp/modules/monitoring/variables.tf
@@ -60,6 +60,8 @@ variable "notification_channel_id" {
 
 locals {
   notification_channels = [format("projects/%v/notificationChannels/%v", var.project_id, var.notification_channel_id)]
+  qualified_rekor_url   = format("https://%s", var.rekor_url)
+  qualified_fulcio_url  = format("https://%s", var.fulcio_url)
 }
 
 // Certificate Authority name for alerting


### PR DESCRIPTION
Add in two more alerts for the sigstore api prober:
* Alert if any endpoint is returning non-200 response codes for over 5 min
* Alert if any endpoint has absent data for over 5 min

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
