### PR TITLE
Add necessary permissions to prometheus SA to export to GCP monitoring

### DIFF
--- a/terraform/gcp/modules/gke_cluster/service_accounts.tf
+++ b/terraform/gcp/modules/gke_cluster/service_accounts.tf
@@ -64,9 +64,16 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_prometheus_probe
   depends_on         = [google_service_account.prometheus-sa, google_container_cluster.cluster]
 }
 
+// Add the service account to the project
 resource "google_project_iam_member" "prometheus_member" {
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+  ])
   project    = var.project_id
-  role       = "roles/monitoring.metricWriter"
+  role       = each.key
   member     = "serviceAccount:${google_service_account.prometheus-sa.email}"
   depends_on = [google_service_account.prometheus-sa]
 }


### PR DESCRIPTION
Under just `monitoring.metricsWriter` the prometheus SA still can't export metrics to GCP. monitoring. failing with this error:

```
level=warn ts=2022-05-19T13:47:34.846Z caller=queue_manager.go:534 component=queue_manager msg="Unrecoverable error sending samples to remote storage" err="rpc error: code = Unauthenticated desc = transport: compute: Received 403 `Unable to generate access token; IAM returned 403 Forbidden: The caller does not have permission\nThis error could be caused by a missing IAM policy binding on the target IAM service account.\nFor more information, refer to the Workload Identity documentation:\n\thttps://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to\n\n`"
```

I got these permissions from this stackdriver issue: https://github.com/Stackdriver/stackdriver-prometheus-sidecar/issues/136

which points to these GCP docs: https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
