### PR TITLE
allow specifying mysql dbname.

### DIFF
--- a/terraform/gcp/modules/external_secrets/external_secrets.tf
+++ b/terraform/gcp/modules/external_secrets/external_secrets.tf
@@ -125,7 +125,7 @@ spec:
     name: trillian-mysql
     template:
       data:
-        mysql-database: trillian
+        mysql-database: "${var.mysql_dbname}"
         mysql-password: "{{ .mysqlPassword | toString }}"  # <-- convert []byte to string
         mysql-user: trillian
   data:

--- a/terraform/gcp/modules/external_secrets/variables.tf
+++ b/terraform/gcp/modules/external_secrets/variables.tf
@@ -31,3 +31,9 @@ variable "project_id" {
     error_message = "Must specify project_id variable."
   }
 }
+
+variable "mysql_dbname" {
+  type        = string
+  description = "Name of MySQL database."
+  default     = "trillian"
+}


### PR DESCRIPTION
The trillian logserver currently reads in the database name from a
secret.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
