### PR TITLE
Alignment period for latency alerts should be 60 seconds

### DIFF
--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -102,12 +102,12 @@ resource "google_monitoring_alert_policy" "fulcio_api_latency_alert" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period   = "300s"
-        per_series_aligner = "ALIGN_MEAN"
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_MAX"
       }
 
       comparison = "COMPARISON_GT"
-      duration   = "0s"
+      duration   = "300s"
       filter     = format("metric.type=\"monitoring.googleapis.com/uptime_check/request_latency\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_fulcio.uptime_check_id)
 
       threshold_value = "750"

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -69,7 +69,7 @@ resource "google_monitoring_alert_policy" "rekor_api_latency_alert" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period   = "300s"
+        alignment_period   = "60s"
         per_series_aligner = "ALIGN_MAX"
       }
 


### PR DESCRIPTION
Right now, the alignment period and the rolling window are both 5 minutes. That means if we have even one data point above the threshold, we get an alert. Instead, calculate the max over the past minute, and alert if it is above threshold for 5 minutes.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
