### PR TITLE
change default mysql version from 8.0 to 5.7

### DIFF
--- a/terraform/gcp/modules/mysql/variables.tf
+++ b/terraform/gcp/modules/mysql/variables.tf
@@ -92,3 +92,8 @@ variable "db_name" {
   default     = "trillian"
 }
 
+variable "database_version" {
+  type        = string
+  description = "MySQL database version."
+  default     = "MYSQL_5_7"
+}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -123,6 +123,7 @@ module "mysql" {
   project_id = var.project_id
 
   cluster_name      = var.cluster_name
+  database_version  = var.mysql_db_version
   tier              = var.mysql_tier
   availability_type = var.mysql_availability_type
 

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -125,6 +125,12 @@ variable "mysql_db_name" {
   default     = "trillian"
 }
 
+variable "mysql_db_version" {
+  type        = string
+  description = "MySQL database version."
+  default     = "MYSQL_5_7"
+}
+
 variable "mysql_tier" {
   type        = string
   description = "Machine tier for MySQL instance."
@@ -160,8 +166,6 @@ variable "mysql_binary_log_backup_enabled" {
   description = "Whether to enable binary log for backup for MySQL instance."
   default     = true
 }
-
-
 
 variable "fulcio_keyring_name" {
   type        = string


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This makes it configurable as well.

The default change is due to performance issue with large amount of data, where large amount of data is a copy of the current sigstore prod database.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
