### PR TITLE
update actions/setup-go to add cache and use the recommend way to get the latest go

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -36,7 +36,7 @@ jobs:
         - fulcio rekor ctlog e2e
 
         go-version:
-          - 1.17.x
+          - 1.17
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -54,6 +54,8 @@ jobs:
       uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v3.0.0
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
+        cache: true
 
     - name: Check out our repo
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,9 @@ jobs:
     steps:
     - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v3.0.0
       with:
-        go-version: 1.17.x
+        go-version: 1.17
+        check-latest: true
+        cache: true
     # will use the latest release available for ko
     - name: Install ko
       uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.17.x
+  GO_VERSION: 1.17
 
 jobs:
   license-check:
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v3.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache: true
+
       - name: Install addlicense
         run: go install github.com/google/addlicense@latest
       - name: Check license headers

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ testimagerefs
 release.yaml
 testrelease.yaml
 kind.yaml
+.vscode/*


### PR DESCRIPTION


#### Summary
- update actions/setup-go to add cache and use the recommend way to get the latest go

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
