### PR TITLE
Add github action to run prober once when it's updated

### DIFF
--- a/.github/workflows/prober-test.yml
+++ b/.github/workflows/prober-test.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      packages: write
       contents: read
     steps:
       - name: 'Checkout'

--- a/.github/workflows/prober-test.yml
+++ b/.github/workflows/prober-test.yml
@@ -1,0 +1,37 @@
+name: Prober Unit Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - 'cmd/prober/**'
+  push:
+    branches:
+      - main
+    paths:
+    - 'cmd/prober/**'
+
+permissions:
+  contents: read
+
+jobs:
+  prober-test:
+    name: 'Prober test'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v3.2.0
+        with:
+          go-version: 1.18
+          check-latest: true
+          
+      - name: Prober test
+        id: prober-test
+        run: go run ./cmd/prober --one-time


### PR DESCRIPTION
this will function as our e2e test

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
