### PR TITLE
Allow custom URLs for Rekor/Fulcio for prober

### DIFF
--- a/terraform/gcp/modules/monitoring/sigstore.tf
+++ b/terraform/gcp/modules/monitoring/sigstore.tf
@@ -77,8 +77,8 @@ module "prober" {
 
   project_id              = var.project_id
   notification_channel_id = var.notification_channel_id
-  rekor_url               = local.qualified_rekor_url
-  fulcio_url              = local.qualified_fulcio_url
+  rekor_url               = var.prober_rekor_url
+  fulcio_url              = var.prober_fulcio_url
 
   depends_on = [
     google_project_service.service

--- a/terraform/gcp/modules/monitoring/variables.tf
+++ b/terraform/gcp/modules/monitoring/variables.tf
@@ -57,6 +57,17 @@ variable "dex_url" {
   default     = "oauth2.sigstore.dev"
 }
 
+// Prober variables
+variable "prober_rekor_url" {
+  type    = string
+  default = "http://rekor-server.rekor-system.svc"
+}
+
+variable "prober_fulcio_url" {
+  type    = string
+  default = "http://fulcio-server.fulcio-system.svc"
+}
+
 // Set-up for notification channel for alerting
 variable "notification_channel_id" {
   type        = string


### PR DESCRIPTION
Since the prober runs in-cluster with Rekor and Fulcio, it can actually use the cluster's internal DNS e.g. `http://rekor-server.rekor-system.svc` instead of using the public domain.

This will give us more accurate server-side latency metrics.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>
