### PR TITLE
add slack token secret

### DIFF
--- a/terraform/gcp/modules/argocd/argocd.tf
+++ b/terraform/gcp/modules/argocd/argocd.tf
@@ -50,6 +50,30 @@ YAML
   ]
 }
 
+resource "kubectl_manifest" "externalsecret_argocd_slack" {
+  yaml_body = <<YAML
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: slack-argocd-notification
+  namespace: "${kubernetes_namespace_v1.argocd.metadata[0].name}"
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcp-backend
+  target:
+    name: argocd-notifications-secret
+  data:
+  - secretKey: slack-token
+    remoteRef:
+      key: "${var.gcp_secret_name_slack_token}"
+YAML
+
+  depends_on = [
+    kubernetes_namespace_v1.argocd
+  ]
+}
+
 resource "helm_release" "argocd" {
   name       = "argocd"
   namespace  = "argocd"
@@ -62,6 +86,7 @@ resource "helm_release" "argocd" {
   ]
 
   depends_on = [
-    kubectl_manifest.externalsecret_argocd_ssh
+    kubectl_manifest.externalsecret_argocd_ssh,
+    kubectl_manifest.externalsecret_argocd_slack
   ]
 }

--- a/terraform/gcp/modules/argocd/variables.tf
+++ b/terraform/gcp/modules/argocd/variables.tf
@@ -33,3 +33,8 @@ variable "gcp_secret_name_ssh" {
   description = "GCP Secret name that holds the SSH key for GitHub repository access."
   type        = string
 }
+
+variable "gcp_secret_name_slack_token" {
+  description = "GCP Secret name that holds the slack token to argocd send notifications."
+  type        = string
+}


### PR DESCRIPTION
#### Summary
Now the argocd has the argo-notification embedded, and we will need to setup the slack token to be able to send notifications to our channel

This PR is the infra and prepare for one that will be opened in the public instance repo


#### Ticket Link
n/a
