### PR TITLE
upgrade kubectl / helm terraform providers

### DIFF
--- a/terraform/gcp/modules/argocd/versions.tf
+++ b/terraform/gcp/modules/argocd/versions.tf
@@ -32,13 +32,11 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "1.13.1"
+      version = "1.14.0"
     }
     helm = {
-      // Using custom built version for proxy access.
-      // Switch to public instance once https://github.com/hashicorp/terraform-provider-helm/pull/834 lands.
-      source  = "nsmith5/helm"
-      version = "2.4.3"
+      source  = "hashicorp/helm"
+      version = "2.6.0"
     }
   }
 }

--- a/terraform/gcp/modules/external_secrets/versions.tf
+++ b/terraform/gcp/modules/external_secrets/versions.tf
@@ -32,13 +32,11 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "1.13.1"
+      version = "1.14.0"
     }
     helm = {
-      // Using custom built version for proxy access.
-      // Switch to public instance once https://github.com/hashicorp/terraform-provider-helm/pull/834 lands.
-      source  = "nsmith5/helm"
-      version = "2.4.3"
+      source  = "hashicorp/helm"
+      version = "2.6.0"
     }
   }
 }


### PR DESCRIPTION
#### Summary
- upgrade kubectl / helm terraform providers


PR `https://github.com/hashicorp/terraform-provider-helm/pull/834` is merged and it is part of the release `v2.6.0`