### PR TITLE
Add Terraform resource for TUF preprod bucket

### DIFF
--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -45,9 +45,9 @@ module "tuf" {
   region     = var.tuf_region == "" ? var.region : var.tuf_region
   project_id = var.project_id
 
-  tuf_bucket    = var.tuf_bucket
-  tuf_preprod_bucket    = var.tuf_preprod_bucket
-  storage_class = var.tuf_storage_class
+  tuf_bucket         = var.tuf_bucket
+  tuf_preprod_bucket = var.tuf_preprod_bucket
+  storage_class      = var.tuf_storage_class
 }
 
 // Monitoring

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -46,6 +46,7 @@ module "tuf" {
   project_id = var.project_id
 
   tuf_bucket    = var.tuf_bucket
+  tuf_preprod_bucket    = var.tuf_preprod_bucket
   storage_class = var.tuf_storage_class
 }
 

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -55,6 +55,11 @@ variable "tuf_bucket" {
   description = "Name of GCS bucket for TUF root."
 }
 
+variable "tuf_preprod_bucket" {
+  type        = string
+  description = "Name of GCS bucket for preprod/staged TUF root."
+}
+
 variable "tuf_storage_class" {
   type        = string
   description = "Storage class for TUF bucket."

--- a/terraform/gcp/modules/tuf/tuf.tf
+++ b/terraform/gcp/modules/tuf/tuf.tf
@@ -67,3 +67,41 @@ resource "google_storage_bucket_iam_member" "public_tuf_member" {
   depends_on = [google_storage_bucket.tuf]
 }
 
+resource "google_storage_bucket" "tuf_preprod" {
+  name     = var.tuf_preprod_bucket
+  location = var.region
+  project  = var.project_id
+
+  storage_class               = var.storage_class
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      with_state         = "ANY"
+      num_newer_versions = 10
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      days_since_noncurrent_time = 730
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "public_tuf_preprod_member" {
+  bucket = google_storage_bucket.tuf_preprod.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+
+  depends_on = [google_storage_bucket.tuf_preprod]
+}

--- a/terraform/gcp/modules/tuf/variables.tf
+++ b/terraform/gcp/modules/tuf/variables.tf
@@ -33,6 +33,11 @@ variable "tuf_bucket" {
   description = "Name of GCS bucket for TUF root."
 }
 
+variable "tuf_preprod_bucket" {
+  type        = string
+  description = "Name of GCS bucket for preprod/staged TUF root."
+}
+
 variable "storage_class" {
   type        = string
   description = "Storage class for TUF root bucket."


### PR DESCRIPTION
This will be used to store the staged TUF prod root before it's synced
to the production bucket, letting us catch issues early.

This is already created in production.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
