### PR TITLE
plumb mysql replica configuration into sigstore module.

### DIFF
--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -128,6 +128,9 @@ module "mysql" {
   tier              = var.mysql_tier
   availability_type = var.mysql_availability_type
 
+  replica_zones = var.mysql_replica_zones
+  replica_tier  = var.mysql_replica_tier
+
   network = module.network.network_self_link
 
   instance_name = var.mysql_instance_name

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -148,6 +148,18 @@ variable "mysql_availability_type" {
   default     = "REGIONAL"
 }
 
+variable "mysql_replica_zones" {
+  description = "List of zones for read replicas."
+  type        = list(any)
+  default     = []
+}
+
+variable "mysql_replica_tier" {
+  type        = string
+  description = "Machine tier for MySQL replica."
+  default     = "db-n1-standard-1"
+}
+
 variable "mysql_ipv4_enabled" {
   type        = bool
   description = "Whether to enable ipv4 for MySQL instance."


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
this is plumbing the changes from https://github.com/sigstore/scaffolding/pull/251 into the sigstore module.

the purpose is to be able to create read replicas in other regions/zones, and in disaster situations, promote these replica as primary. these replicas is a better option than backups, where backups are daily, read replicas are on the order of minutes behind typically.



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->