### PR TITLE
remove token creator role for external secrets.

### DIFF
--- a/terraform/gcp/modules/external_secrets/external_secrets.tf
+++ b/terraform/gcp/modules/external_secrets/external_secrets.tf
@@ -47,13 +47,6 @@ resource "google_project_iam_member" "external_secrets_binding" {
   depends_on = [google_service_account.external_secrets_sa]
 }
 
-resource "google_project_iam_member" "external_secrets_binding_token" {
-  project    = var.project_id
-  role       = "roles/iam.serviceAccountTokenCreator"
-  member     = "serviceAccount:${google_service_account.external_secrets_sa.email}"
-  depends_on = [google_service_account.external_secrets_sa]
-}
-
 resource "google_service_account_iam_member" "gke_sa_iam_member_external_secrets" {
   service_account_id = google_service_account.external_secrets_sa.name
   role               = "roles/iam.workloadIdentityUser"
@@ -76,14 +69,6 @@ spec:
   provider:
       gcpsm:
         projectID: "${var.project_id}"
-        auth:
-          workloadIdentity:
-            clusterLocation: "${var.cluster_location}"
-            clusterName: "${var.cluster_name}"
-            clusterProjectID: "${var.project_id}"
-            serviceAccountRef:
-              name: local.k8s_sa
-              namespace: local.namespace
 YAML
 
   depends_on = [helm_release.external_secrets]


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

remove token creator role for external secret.
we should be able to leverage the existing service account for access.

ref:
https://external-secrets.io/v0.4.4/provider-google-secrets-manager/#using-pod-based-workload-identity
https://github.com/sigstore/public-good-instance/blob/main/terraform/environments/staging/helm-charts-values/external-secrets.yaml#L15

FYI: @var-sdk

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->