### PR TITLE
Roles should be applied directly to the mysql service account

### DIFF
--- a/terraform/gcp/modules/mysql/mysql.tf
+++ b/terraform/gcp/modules/mysql/mysql.tf
@@ -71,18 +71,24 @@ resource "google_project_iam_member" "db_admin_member_trillian" {
 }
 
 resource "google_service_account_iam_member" "gke_sa_iam_member_trillian_logserver" {
+  service_account_id = google_service_account.dbuser_trillian.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[trillian-system/trillian-logserver]"
+  depends_on         = [google_service_account.dbuser_trillian]
+}
+
+resource "google_project_iam_member" "logserver_iam" {
   # // Give trillian logserver permission to export metrics to Stackdriver
   for_each = toset([
-    "roles/iam.workloadIdentityUser",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/stackdriver.resourceMetadata.writer",
     "roles/cloudtrace.agent"
   ])
-  service_account_id = google_service_account.dbuser_trillian.name
-  role               = each.key
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[trillian-system/trillian-logserver]"
-  depends_on         = [google_service_account.dbuser_trillian]
+  project    = var.project_id
+  role       = each.key
+  member     = "serviceAccount:${google_service_account.dbuser_trillian.email}"
+  depends_on = [google_service_account.dbuser_trillian]
 }
 
 resource "google_service_account_iam_member" "gke_sa_iam_member_trillian_logsigner" {


### PR DESCRIPTION
was applying the roles to the wrong type of service account, this should fix it

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->