### PR TITLE
Document action better.

### DIFF
--- a/actions/setup/README.md
+++ b/actions/setup/README.md
@@ -4,17 +4,21 @@ This action installs sigstore components and wires them together for test
 purposes on an existing cluster. Also verifies they are up and running by
 doing a cosign sign/verify.
 
-**Deprecated**
-Will also set up the environment variables so that calling
-cosign can be used for keyless signing / verification against the cluster. But because Scaffolding now supports TUF, that is the best way to exercise the
-cluster. The legacy way with environment variables will be removed in the
-future, not only from Scaffolding but maybe from Cosign.
+Will also set up URL endpoints for Rekor, Fulcio, and TUF so that you can use
+for example `cosign` to test against this installation of Sigstore. You have
+to initialize `cosign` explicitly like this:
 
-The action sets up the TUF root on the cluster and there you have to initialize
-`cosign` explicity for it after running the action.
 ```shell
 cosign initialize --mirror $TUF_MIRROR --root ./root.json
 ```
+
+**Deprecated**
+For older versions of Scaffolding, you can set `legacy-variables` to "true",
+which is currently the default. When setting this you will not use TUF but
+instead, specify the various public keys and certs via local files and
+use environment variables to point to them. The legacy way with environment
+variables will be removed in the future, not only from Scaffolding but
+likely from Cosign.
 
 ## Usage
 
@@ -23,6 +27,8 @@ cosign initialize --mirror $TUF_MIRROR --root ./root.json
   with:
     # Scaffolding version. 'latest-release' by default.
     scaffolding-version: "v0.4.2"
+    # Do not set the deprecated environment variables, use TUF instead
+    legacy-variables: "false"
 ```
 
 ## Scenarios
@@ -36,36 +42,37 @@ steps:
 
 The following environmental variables are exported.
 
- * REKOR_URL
-   Where Rekor runs. For cosign commands, you should use this for --rekor-url
-   flag
- * FULCIO_URL
-   Where Fulcio runs. For cosign commands, you should use this for --fulcio-url
-   flag
- * CTLOG_URL
-   CTLog where Fulcio writes.
- * SIGSTORE_CT_LOG_PUBLIC_KEY_FILE
-   Public key file location. Used by cosign to validate SCT coming back from
-   Fulcio.
- * SIGSTORE_ROOT_FILE
-   Alternate sigstore root file, since we are using non-standard root for
-   sigstore components.
- * SIGSTORE_REKOR_API_PUBLIC_KEY
-   Necessary to be set with the location of the public key file, so that we can validate against non-standard
-   Rekor instance that we use above.
- * ISSUER_URL
-   This is the URL for fetching OIDC tokens off the cluster that you can then use as inputs to --identity-token to cosign
- * OIDC_TOKEN
-   This is an already fetched OIDC token. Convenience if your tests do
-   not run longer than 10 minutes, which is how long this token is
-   valid for. If your tests run longer than this is valid, you can use
-   `ISSUER_URL` above to fetch a new token.
  * TUF_MIRROR
    This is the TUF mirror installed on to the cluster. You have to then
    initialize cosign like so:
    ```shell
    cosign initialize --mirror $TUF_MIRROR --root ./root.json
    ```
+ * REKOR_URL
+   Where Rekor runs. For cosign commands, you should use this for --rekor-url
+   flag
+ * FULCIO_URL
+   Where Fulcio runs. For cosign commands, you should use this for
+   --fulcio-url flag
+ * CTLOG_URL
+   CTLog Fulcio uses for Certificate Transparency Log.
+ * ISSUER_URL
+   This is the URL for fetching OIDC tokens off the cluster that you can then use as inputs to --identity-token to `cosign`
+ * OIDC_TOKEN
+   This is an already fetched OIDC token. Convenience if your tests do
+   not run longer than 10 minutes, which is how long this token is
+   valid for. If your tests run longer than this is valid, you can use
+   `ISSUER_URL` above to fetch a new token by specifying
+   --identity-token=$(curl -s $ISSUER_URL)
+ * SIGSTORE_CT_LOG_PUBLIC_KEY_FILE **DEPRECATED**
+   Public key file location. Used by cosign to validate SCT coming back from
+   Fulcio.
+ * SIGSTORE_ROOT_FILE **DEPRECATED**
+   Alternate sigstore root file, since we are using non-standard root for
+   sigstore components.
+ * SIGSTORE_REKOR_API_PUBLIC_KEY **DEPRECATED**
+   Necessary to be set with the location of the public key file, so that we can validate against non-standard
+   Rekor instance that we use above.
 
 ## TUF Root file
 The action also creates a ./root.json that contains the TUF root that you use


### PR DESCRIPTION


Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The way the current documentation read made it seem like the whole action was deprecated. So took
a crack at making it more explicit that TUF way is the proper way to use it, and the various env / local key
files was deprecated in favour of TUF. Also explicitly point out which env variables are deprecated.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Deprecate the legacy env variables in favour of TUF: SIGSTORE_CT_LOG_PUBLIC_KEY_FILE, SIGSTORE_ROOT_FILE, SIGSTORE_REKOR_API_PUBLIC_KEY

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->