### PR TITLE
Add flag sigstore-only for installing into existing clusters

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Version of scaffolding to install (v0.4.0, latest-release.)'
     required: true
     default: 'latest-release'
+  sigstore-only:
+    description: 'If set to "true" will not install kind cluster, only Sigstore'
+    required: true
+    default: 'false'
   knative-version:
     description: 'Version of Knative to install (1.1.0, 1.1.1, etc.)'
     required: true
@@ -53,12 +57,6 @@ runs:
     run: |
       set -ex
 
-      # Configure DockerHub mirror
-      tmp=$(mktemp)
-      jq '."registry-mirrors" = ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmp"
-      sudo mv "$tmp" /etc/docker/daemon.json
-      sudo service docker restart
-
       # Determine which version to install
       # - if version is "latest-release", look up latest release.
       # - otherwise, install the specified version.
@@ -70,21 +68,29 @@ runs:
         tag="${{ inputs.version }}"
       esac
 
-      echo "Installing kind and knative using release"
-      curl -Lo ./setup-kind.sh https://github.com/sigstore/scaffolding/releases/download/${tag}/setup-kind.sh
-        chmod u+x ./setup-kind.sh
-        ./setup-kind.sh \
-          --registry-url ${{ inputs.registry-name }}:${{ inputs.registry-port }} \
-          --cluster-suffix ${{ inputs.cluster-suffix }} \
-          --k8s-version ${{ inputs.k8s-version }} \
-          --knative-version ${{ inputs.knative-version }}
-
       # At release v0.4.0 we added support for TUF, and rejiggered
       # the install process, so check to see if we are running >=4
       MINOR=$(echo $tag | cut -d '.' -f 2)
       INSTALL_TUF="false"
       if [ ${MINOR} -ge 4 ]; then
         INSTALL_TUF="true"
+      fi
+
+      if [ ${{ inputs.sigstore-only }} == "false" ]; then
+        # Configure DockerHub mirror
+        tmp=$(mktemp)
+        jq '."registry-mirrors" = ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmp"
+        sudo mv "$tmp" /etc/docker/daemon.json
+        sudo service docker restart
+
+        echo "Installing kind and knative using release"
+        curl -Lo ./setup-kind.sh https://github.com/sigstore/scaffolding/releases/download/${tag}/setup-kind.sh
+        chmod u+x ./setup-kind.sh
+        ./setup-kind.sh \
+          --registry-url ${{ inputs.registry-name }}:${{ inputs.registry-port }} \
+          --cluster-suffix ${{ inputs.cluster-suffix }} \
+          --k8s-version ${{ inputs.k8s-version }} \
+          --knative-version ${{ inputs.knative-version }}
       fi
 
       echo "Installing sigstore scaffolding @ ${tag}"
@@ -124,7 +130,6 @@ runs:
         echo "REKOR_URL=$REKOR_URL" >> $GITHUB_ENV
         curl -s $REKOR_URL/api/v1/log/publicKey > ./rekor-public.pem
         echo "SIGSTORE_REKOR_PUBLIC_KEY=./rekor-public.pem" >> $GITHUB_ENV
-
       else
         echo "This version does have support for TUF"
         curl -Lo /tmp/setup-scaffolding-from-release.sh https://github.com/sigstore/scaffolding/releases/download/${tag}/setup-scaffolding-from-release.sh


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
It would be handy to decouple the construction of a cluster and installing the Sigstore pieces, so make it a configurable
flag `sigstore-only`. This allows action to be used to install into existing cluster.


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Add `sigstore-only` flag to github-action so that you can install only the sigstore pieces into existing cluster.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->