### PR TITLE
add prober to build and release the image/manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_TAG)
 KO_DOCKER_REPO ?= ghcr.io/sigstore/scaffolding
 
 # These are the subdirs under config that we'll turn into separate artifacts.
-artifacts := trillian ctlog fulcio rekor tuf
+artifacts := trillian ctlog fulcio rekor tuf prober
 
 .PHONY: ko-resolve
 ko-resolve:


### PR DESCRIPTION
#### Summary
- add prober to build and release the image/manifests

Fixes #283 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->