### PR TITLE
Fix issue #129

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -127,15 +127,19 @@ jobs:
         sed 's@"--secret=ctlog-secret"@"--secret=ctlog-secret","--config-in-secret"@' config/ctlog/certs/300-createconfig.yaml > ./300-createconfig-new.yaml
         mv ./300-createconfig-new.yaml config/ctlog/certs/300-createconfig.yaml
 
+        cat config/ctlog/certs/300-createconfig.yaml
+
         # Then patch in the ctlog to mount the secret instead of the configmap.
         cp config/ctlog/ctlog/300-ctlog.yaml ./300-ctlog.yaml
         # The sed works differently in mac and other places, so just shuffle
         # files around for now.
         sed 's@configMap:@secret:@' config/ctlog/ctlog/300-ctlog.yaml > ./300-ctlog-tmp.yaml
 
-        sed 's@name: ctlog-config@secretName: ctlog-config@' 300-ctlog-tmp.yaml > ./300-ctlog-new.yaml
+        sed 's@name: ctlog-config@secretName: ctlog-secret@' 300-ctlog-tmp.yaml > ./300-ctlog-new.yaml
         rm 300-ctlog-tmp.yaml
         mv ./300-ctlog-new.yaml config/ctlog/ctlog/300-ctlog.yaml
+
+        cat config/ctlog/ctlog/300-ctlog.yaml
 
     - name: Install scaffolding
       run: |

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -117,7 +117,7 @@ jobs:
     # We do this by screwing around with the existing config files for now
     # instead of creating a whole set of parallel files for these.
     - name: Configure CTLog config storage
-      if: ${{ matrix.ctlog-in-secret == "true" }}
+      if: ${{ matrix.ctlog-in-secret == 'true' }}
       run: |
         echo "Fixing CTLog config to use secrets"
         # First patch in the flag that creates the ctlog config in the secret.
@@ -139,7 +139,7 @@ jobs:
         ./hack/setup-scaffolding.sh
 
     - name: Restore CTLog config storage
-      if: ${{ matrix.ctlog-in-secret == "true" }}
+      if: ${{ matrix.ctlog-in-secret == 'true' }}
       run: |
         echo "Restore CTLog config to not use secrets"
         mv ./300-createconfig.yaml config/ctlog/certs/300-createconfig.yaml

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -31,6 +31,10 @@ jobs:
         leg:
         - fulcio rekor ctlog e2e
 
+        ctlog-in-secret:
+        - "true"
+        - "false"
+
         go-version:
         - 1.18
 
@@ -109,9 +113,37 @@ jobs:
         echo Created image $demoimage
         popd
 
+    # Configure the CTLog either to be stored in the secret or configmap.
+    # We do this by screwing around with the existing config files for now
+    # instead of creating a whole set of parallel files for these.
+    - name: Configure CTLog config storage
+      if: ${{ matrix.ctlog-in-secret == "true" }}
+      run: |
+        echo "Fixing CTLog config to use secrets"
+        # First patch in the flag that creates the ctlog config in the secret.
+        cp config/ctlog/certs/300-createconfig.yaml ./300-createconfig.yaml
+        # The sed works differently in mac and other places, so just shuffle
+        # files around for now.
+        sed 's@"--secret=ctlog-secret"@"--secret=ctlog-secret","--config-in-secret"@' config/ctlog/certs/300-createconfig.yaml > ./300-createconfig-new.yaml
+        mv ./300-createconfig-new.yaml config/ctlog/certs/300-createconfig.yaml
+
+        # Then patch in the ctlog to mount the secret instead of the configmap.
+        cp config/ctlog/ctlog/300-ctlog.yaml ./300-ctlog.yaml
+        # The sed works differently in mac and other places, so just shuffle
+        # files around for now.
+        sed 's@configMap:@secret:@'' config/ctlog/ctlog/300-ctlog.yaml > ./300-ctlog-new.yaml
+        mv ./300-ctlog-new.yaml config/ctlog/ctlog/300-ctlog.yaml
+
     - name: Install scaffolding
       run: |
         ./hack/setup-scaffolding.sh
+
+    - name: Restore CTLog config storage
+      if: ${{ matrix.ctlog-in-secret == "true" }}
+      run: |
+        echo "Restore CTLog config to not use secrets"
+        mv ./300-createconfig.yaml config/ctlog/certs/300-createconfig.yaml
+        mv ./300-ctlog.yaml config/ctlog/ctlog/300-ctlog.yaml
 
     - name: Initialize cosign with our custom tuf root and make root copy
       run: |

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -131,7 +131,7 @@ jobs:
         cp config/ctlog/ctlog/300-ctlog.yaml ./300-ctlog.yaml
         # The sed works differently in mac and other places, so just shuffle
         # files around for now.
-        sed 's@configMap:@secret:@'' config/ctlog/ctlog/300-ctlog.yaml > ./300-ctlog-new.yaml
+        sed 's@configMap:@secret:@' config/ctlog/ctlog/300-ctlog.yaml > ./300-ctlog-new.yaml
         mv ./300-ctlog-new.yaml config/ctlog/ctlog/300-ctlog.yaml
 
     - name: Install scaffolding

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -131,7 +131,10 @@ jobs:
         cp config/ctlog/ctlog/300-ctlog.yaml ./300-ctlog.yaml
         # The sed works differently in mac and other places, so just shuffle
         # files around for now.
-        sed 's@configMap:@secret:@' config/ctlog/ctlog/300-ctlog.yaml > ./300-ctlog-new.yaml
+        sed 's@configMap:@secret:@' config/ctlog/ctlog/300-ctlog.yaml > ./300-ctlog-tmp.yaml
+
+        sed 's@name: ctlog-config@secretName: ctlog-config@' 300-ctlog-tmp.yaml > ./300-ctlog-new.yaml
+        rm 300-ctlog-tmp.yaml
         mv ./300-ctlog-new.yaml config/ctlog/ctlog/300-ctlog.yaml
 
     - name: Install scaffolding


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix #129 
Introduce a flag, config-in-secret which will write the marshalled ctlog configuration into the secret instead of configmap.

#### Release Note
 * Add `config-in-secret` flag which if set to true will make it so the ctlog config will get written in the secret specified with `secret` under the key `config`.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->