### PR TITLE
Update alignment period and duration for api prober error codes alert

### DIFF
--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -140,6 +140,8 @@ resource "google_monitoring_alert_policy" "prober_data_absent_alert" {
   project               = var.project_id
 }
 
+// This alert will fire if a non-200 error code is seen over the past 60s (alignment_period)
+// AND if this sustains for 5 minutes (duration)
 resource "google_monitoring_alert_policy" "prober_error_codes" {
   alert_strategy {
     auto_close = "604800s"
@@ -150,14 +152,14 @@ resource "google_monitoring_alert_policy" "prober_error_codes" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period     = "300s"
+        alignment_period     = "60s"
         cross_series_reducer = "REDUCE_MAX"
         group_by_fields      = ["metric.label.endpoint"]
         per_series_aligner   = "ALIGN_RATE"
       }
 
       comparison      = "COMPARISON_GT"
-      duration        = "0s"
+      duration        = "300s"
       filter          = "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/api_endpoint_latency_count/summary\" AND metric.labels.status_code != \"200\""
       threshold_value = "0"
 


### PR DESCRIPTION
Previously this alert was misconfigured to fire every time a non-200 error code was seen.
Instead, we want to track the % of non-200 codes over the past minute (alignment_period).
If the % is nonzero for >5 minutes (duration), then send the alert.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->