### PR TITLE
Disable fulcio endpoint latency alert

### DIFF
--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -93,7 +93,7 @@ resource "google_monitoring_alert_policy" "prober_fulcio_endpoint_latency" {
     mime_type = "text/markdown"
   }
 
-  enabled               = "true"
+  enabled               = "false"
   notification_channels = local.notification_channels
   project               = var.project_id
 }


### PR DESCRIPTION
We are no longer alerting on latency

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

