### PR TITLE
uptime alerts: only page if we see a failure every minute for 5 consecutive min

### DIFF
--- a/terraform/gcp/modules/monitoring/dex/dex_alerts.tf
+++ b/terraform/gcp/modules/monitoring/dex/dex_alerts.tf
@@ -40,7 +40,7 @@ resource "google_monitoring_uptime_check_config" "uptime_dex" {
   timeout = "10s"
 }
 
-# Alert for Dex uptime
+// Alert if we see a failure every minute for 5 consecutive minutes
 resource "google_monitoring_alert_policy" "dex_uptime_alert" {
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
@@ -51,14 +51,14 @@ resource "google_monitoring_alert_policy" "dex_uptime_alert" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period     = "300s"
+        alignment_period     = "60s"
         cross_series_reducer = "REDUCE_COUNT_FALSE"
         group_by_fields      = ["resource.*"]
         per_series_aligner   = "ALIGN_NEXT_OLDER"
       }
 
       comparison      = "COMPARISON_GT"
-      duration        = "60s"
+      duration        = "300s"
       filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_dex.uptime_check_id)
       threshold_value = "1"
 

--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-# Alert for Fulcio uptime
+// Alert if we see a failure every minute for 5 consecutive minutes
 resource "google_monitoring_alert_policy" "fulcio_uptime_alert" {
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
@@ -25,14 +25,14 @@ resource "google_monitoring_alert_policy" "fulcio_uptime_alert" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period     = "300s"
+        alignment_period     = "60s"
         cross_series_reducer = "REDUCE_COUNT_FALSE"
         group_by_fields      = ["resource.*"]
         per_series_aligner   = "ALIGN_NEXT_OLDER"
       }
 
       comparison      = "COMPARISON_GT"
-      duration        = "60s"
+      duration        = "300s"
       filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_fulcio.uptime_check_id)
       threshold_value = "1"
 
@@ -52,7 +52,7 @@ resource "google_monitoring_alert_policy" "fulcio_uptime_alert" {
   depends_on            = [google_monitoring_uptime_check_config.uptime_fulcio]
 }
 
-# Alert for CT Log uptime
+// Alert if we see a failure every minute for 5 consecutive minutes
 resource "google_monitoring_alert_policy" "ctlog_uptime_alert" {
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
@@ -63,7 +63,7 @@ resource "google_monitoring_alert_policy" "ctlog_uptime_alert" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period     = "300s"
+        alignment_period     = "60s"
         cross_series_reducer = "REDUCE_COUNT_FALSE"
         group_by_fields      = ["resource.*"]
         per_series_aligner   = "ALIGN_NEXT_OLDER"

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-# Alert for Rekor uptime: GET
+// Alert if we see a failure every minute for 5 consecutive minutes
 resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
   for_each = toset(var.api_endpoints_get)
 
@@ -27,14 +27,14 @@ resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
   conditions {
     condition_threshold {
       aggregations {
-        alignment_period     = "300s"
+        alignment_period     = "60s"
         cross_series_reducer = "REDUCE_COUNT_FALSE"
         group_by_fields      = ["resource.*"]
         per_series_aligner   = "ALIGN_NEXT_OLDER"
       }
 
       comparison = "COMPARISON_GT"
-      duration   = "60s"
+      duration   = "300s"
       filter     = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.rekor_uptime_alerts_get[format("%s", each.key)].uptime_check_id)
 
       threshold_value = "1"


### PR DESCRIPTION
The way this is set up at the moment, we will fire an alert every time an uptime check fails

uptime checks happen every minute

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

