### PR TITLE
remove use of Rekor version endpoint

### DIFF
--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -28,13 +28,9 @@ type ReadProberCheck struct {
 
 var RekorEndpoints = []ReadProberCheck{
 	{
-		endpoint: "/api/v1/version",
-		method:   GET,
-	}, {
 		endpoint: "/api/v1/log/publicKey",
 		method:   GET,
-	},
-	{
+	}, {
 		endpoint: "/api/v1/log",
 		method:   GET,
 	}, {

--- a/terraform/gcp/modules/monitoring/rekor/variables.tf
+++ b/terraform/gcp/modules/monitoring/rekor/variables.tf
@@ -39,7 +39,6 @@ variable "api_endpoints_get" {
   type = list(string)
   default = [
     "/",
-    "/api/v1/version",
     "/api/v1/log",
     "/api/v1/log/publicKey",
   ]


### PR DESCRIPTION
https://github.com/sigstore/rekor/pull/1022 proposes to remove the /api/v1/version endpoint, so removing its use here.

Signed-off-by: Bob Callaway <bcallaway@google.com>
