### PR TITLE
Use ctlog.config for creating certs, add managecaroots job, tests.

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -165,6 +165,8 @@ jobs:
       run: |
         ko apply -BRf ./testdata/config/new-fulcio
         kubectl wait --timeout 5m -n fulcio-system --for=condition=Ready ksvc fulcio-new
+        NEW_FULCIO_URL=$(kubectl -n fulcio-system get ksvc fulcio-new -ojsonpath='{.status.url}')
+        echo "NEW_FULCIO_URL=$NEW_FULCIO_URL" >> $GITHUB_ENV
 
     - name: Add new Fulcio to ctlog as trusted Fulcio
       run: |
@@ -177,11 +179,41 @@ jobs:
         kubectl -n ctlog-system get pods -oname | xargs kubectl -n ctlog-system delete
         sleep 10
 
-    # TODO: Verify these properly, add the new Fulcio to TUF root, sign & verify
     - name: Dump the trusted certs
       run: |
         curl ${{ env.CTLOG_URL }}/sigstorescaffolding/ct/v1/get-roots | jq .certificates
 
+    - name: Verify both Fulcio certs are there
+      run: |
+        go run ./cmd/ctlog/verifyfulcio/main.go \
+        --ctlog-url ${{ env.CTLOG_URL }} \
+        --log-prefix sigstorescaffolding \
+        --fulcio-url ${{ env.FULCIO_URL }} \
+        --fulcio-url ${{ env.NEW_FULCIO_URL }}
+
+    - name: Remove old Fulcio from ctlog as trusted Fulcio
+      run: |
+        ko apply -BRf ./testdata/config/remove-old-fulcio
+        sleep 2
+        kubectl -n ctlog-system wait --for=condition=Complete --timeout=180s job/remove-fulcio
+
+    - name: Restart ctlog pod again to pick up the changes
+      run: |
+        kubectl -n ctlog-system get pods -oname | xargs kubectl -n ctlog-system delete
+        sleep 10
+
+    - name: Dump the trusted certs
+      run: |
+        curl ${{ env.CTLOG_URL }}/sigstorescaffolding/ct/v1/get-roots | jq .certificates
+
+    - name: Verify that only new Fulcio cert is there
+      run: |
+        go run ./cmd/ctlog/verifyfulcio/main.go \
+        --ctlog-url ${{ env.CTLOG_URL }} \
+        --log-prefix sigstorescaffolding \
+        --fulcio-url ${{ env.NEW_FULCIO_URL }}
+
+    # TODO: Add the new Fulcio to TUF root, sign & verify.
     - name: Collect diagnostics
       if: ${{ failure() }}
       uses: chainguard-dev/actions/kind-diag@main

--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -188,8 +188,8 @@ jobs:
         go run ./cmd/ctlog/verifyfulcio/main.go \
         --ctlog-url ${{ env.CTLOG_URL }} \
         --log-prefix sigstorescaffolding \
-        --fulcio-url ${{ env.FULCIO_URL }} \
-        --fulcio-url ${{ env.NEW_FULCIO_URL }}
+        --fulcio ${{ env.FULCIO_URL }} \
+        --fulcio ${{ env.NEW_FULCIO_URL }}
 
     - name: Remove old Fulcio from ctlog as trusted Fulcio
       run: |
@@ -211,7 +211,7 @@ jobs:
         go run ./cmd/ctlog/verifyfulcio/main.go \
         --ctlog-url ${{ env.CTLOG_URL }} \
         --log-prefix sigstorescaffolding \
-        --fulcio-url ${{ env.NEW_FULCIO_URL }}
+        --fulcio ${{ env.NEW_FULCIO_URL }}
 
     # TODO: Add the new Fulcio to TUF root, sign & verify.
     - name: Collect diagnostics

--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -1,0 +1,189 @@
+name: Key rotation for Fulcio E2E Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions: read-all
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./src/github.com/sigstore/scaffolding
+
+concurrency:
+  group: fulcio-key-rotation-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  fulcio-key-rotation:
+    name: e2e tests for fulcio key rotation
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        k8s-version:
+        - v1.25.x
+
+        leg:
+        - fulcio-key-rotation
+
+        go-version:
+        - 1.18
+
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: on
+      GOFLAGS: -ldflags=-s -ldflags=-w
+      KO_DOCKER_REPO: registry.local:5000/knative
+      KOCACHE: ~/ko
+      COSIGN_EXPERIMENTAL: true
+
+    steps:
+    - uses: chainguard-dev/actions/setup-mirror@main
+    # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+
+    - name: Set up Go
+      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
+      with:
+        go-version: ${{ matrix.go-version }}
+        check-latest: true
+
+    - name: Check out our repo
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      with:
+        path: ./src/github.com/sigstore/scaffolding
+
+    - uses: actions/cache@v3
+      with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ${{ env.KOCACHE }}
+        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ matrix.go-version }}-
+
+    - uses: imjasonh/setup-ko@v0.6
+      with:
+        version: v0.12.0
+
+    - uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 # v2
+
+    - name: Setup Cluster
+      uses: chainguard-dev/actions/setup-kind@main
+      id: kind
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+        registry-authority: registry.local:5000
+        cluster-suffix: cluster.local
+
+    - name: Setup Knative
+      uses: chainguard-dev/actions/setup-knative@main
+      with:
+        version: "latest"
+        serving-features: >
+          {
+            "kubernetes.podspec-fieldref": "enabled"
+          }
+
+    - name: Create sample image
+      run: |
+        pushd $(mktemp -d)
+        go mod init example.com/demo
+        cat <<EOF > main.go
+        package main
+        import "fmt"
+        func main() {
+          fmt.Println("hello world")
+        }
+        EOF
+        demoimage=`ko publish -B example.com/demo`
+        echo "demoimage=$demoimage" >> $GITHUB_ENV
+        echo Created image $demoimage
+        popd
+
+    - name: Install scaffolding
+      run: |
+        ./hack/setup-scaffolding.sh
+
+    - name: Initialize cosign with our custom tuf root and make root copy
+      run: |
+        kubectl -n tuf-system get secrets tuf-root -ojsonpath='{.data.root}' | base64 -d > ./root.json
+        TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
+        echo "TUF_MIRROR=$TUF_MIRROR" >> $GITHUB_ENV
+        # Then initialize cosign
+        cosign initialize --mirror $TUF_MIRROR --root ./root.json
+        # Make copy of the tuf root in the default namespace for tests
+        kubectl -n tuf-system get secrets tuf-root -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl create -f -
+
+    - name: Run signing job in k8s using kubernetes tokens in the cluster
+      run: |
+        make ko-apply-sign-job
+        kubectl wait --for=condition=Complete --timeout=90s job/sign-job
+
+    - name: Verify the image with cosign using kubernetes tokens in the cluster
+      run: |
+        make ko-apply-verify-job
+        kubectl wait --for=condition=Complete --timeout=180s job/verify-job
+
+    - name: Install a Knative service for fetch tokens off the cluster
+      run: |
+        make ko-apply-gettoken
+        sleep 2
+        kubectl wait --for=condition=Ready --timeout=15s ksvc gettoken
+
+    - name: Get the endpoints on the cluster
+      run: |
+        REKOR_URL=$(kubectl -n rekor-system get ksvc rekor -ojsonpath='{.status.url}')
+        echo "REKOR_URL=$REKOR_URL" >> $GITHUB_ENV
+
+        FULCIO_URL=$(kubectl -n fulcio-system get ksvc fulcio -ojsonpath='{.status.url}')
+        echo "FULCIO_URL=$FULCIO_URL" >> $GITHUB_ENV
+
+        CTLOG_URL=$(kubectl -n ctlog-system get ksvc ctlog -ojsonpath='{.status.url}')
+        echo "CTLOG_URL=$CTLOG_URL" >> $GITHUB_ENV
+
+        ISSUER_URL=$(kubectl get ksvc gettoken -ojsonpath='{.status.url}')
+        echo "ISSUER_URL=$ISSUER_URL" >> $GITHUB_ENV
+        OIDC_TOKEN=`curl -s $ISSUER_URL`
+        echo "OIDC_TOKEN=$OIDC_TOKEN" >> $GITHUB_ENV
+
+    - name: Sign with cosign from the action using k8s token
+      run: |
+        cosign sign --rekor-url ${{ env.REKOR_URL }} --fulcio-url ${{ env.FULCIO_URL }} --force --allow-insecure-registry ${{ env.demoimage }} --identity-token ${{ env.OIDC_TOKEN }}
+
+    - name: Verify with cosign from the action using k8s token
+      run: |
+        cosign verify --rekor-url ${{ env.REKOR_URL }} --allow-insecure-registry ${{ env.demoimage }}
+
+    - name: Spin up a new Fulcio with new keys
+      run: |
+        ko apply -BRf ./testdata/config/new-fulcio
+        kubectl wait --timeout 5m -n fulcio-system --for=condition=Ready ksvc fulcio-new
+
+    - name: Add new Fulcio to ctlog as trusted Fulcio
+      run: |
+        ko apply -BRf ./testdata/config/add-new-fulcio
+        sleep 2
+        kubectl -n ctlog-system wait --for=condition=Complete --timeout=180s job/add-fulcio
+
+    - name: Restart ctlog pod
+      run: |
+        kubectl -n ctlog-system get pods -oname | xargs kubectl -n ctlog-system delete
+        sleep 10
+
+    # TODO: Verify these properly, add the new Fulcio to TUF root, sign & verify
+    - name: Dump the trusted certs
+      run: |
+        curl ${{ env.CTLOG_URL }}/sigstorescaffolding/ct/v1/get-roots | jq .certificates
+
+    - name: Collect diagnostics
+      if: ${{ failure() }}
+      uses: chainguard-dev/actions/kind-diag@main
+      with:
+        artifact-name: logs.${{ matrix.k8s-version }}

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -47,7 +47,7 @@ jobs:
 
     # Install cosign
     - name: Install cosign
-      uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 # v2
+      uses: sigstore/cosign-installer@b3413d484cc23cf8778c3d2aa361568d4eb54679 # v2
 
     - name: Set up Go
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
@@ -55,10 +55,9 @@ jobs:
         go-version: ${{ matrix.go-version }}
         check-latest: true
 
-    # Setup ko
-    - uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d # v0.4
+    - uses: imjasonh/setup-ko@v0.6
       with:
-        version: tip
+        version: v0.12.0
 
     - name: Create sample image
       run: |

--- a/cmd/ctlog/createctconfig/main.go
+++ b/cmd/ctlog/createctconfig/main.go
@@ -60,7 +60,7 @@ var (
 	ctlogPrefix        = flag.String("log-prefix", "sigstorescaffolding", "Prefix to append to the url. This is basically the name of the log.")
 	fulcioURL          = flag.String("fulcio-url", "http://fulcio.fulcio-system.svc", "Where to fetch the fulcio Root CA from")
 	trillianServerAddr = flag.String("trillian-server", "log-server.trillian-system.svc:80", "Address of the gRPC Trillian Admin Server (host:port)")
-	keyType            = flag.String("keytype", "ecdsa", "Which private key to generate [rsa,ecdsa")
+	keyType            = flag.String("keytype", "ecdsa", "Which private key to generate [rsa,ecdsa]")
 	keyPassword        = flag.String("key-password", "test", "Password for encrypting the PEM key")
 )
 

--- a/cmd/ctlog/managectroots/main.go
+++ b/cmd/ctlog/managectroots/main.go
@@ -50,11 +50,11 @@ var (
 	operation        = flag.String("operation", "", "Operation to perform for the specified fulcio [add,remove]")
 )
 
-type fulcioOp string
+type ctRootOp string
 
 const (
-	Add    fulcioOp = "ADD"
-	Remove fulcioOp = "REMOVE"
+	Add    ctRootOp = "ADD"
+	Remove ctRootOp = "REMOVE"
 )
 
 func main() {
@@ -66,8 +66,8 @@ func main() {
 
 	ctx := signals.NewContext()
 
-	var op fulcioOp
-	switch fulcioOperation := *operation; fulcioOperation {
+	var op ctRootOp
+	switch ctRootOperation := *operation; ctRootOperation {
 	case "add":
 		op = Add
 	case "remove":
@@ -77,7 +77,7 @@ func main() {
 	}
 
 	versionInfo := version.GetVersionInfo()
-	logging.FromContext(ctx).Infof("running managefulcio Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+	logging.FromContext(ctx).Infof("running managectroots Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
 
 	logging.FromContext(ctx).Infof("%sing %s", op, *fulcioURL)
 

--- a/cmd/ctlog/managefulcio/main.go
+++ b/cmd/ctlog/managefulcio/main.go
@@ -137,7 +137,6 @@ func main() {
 	if err != nil {
 		logging.FromContext(ctx).Fatalf("Failed to unmarshal: %s", err)
 	}
-	logging.FromContext(ctx).Infof("Current Config:\n%s", conf.String())
 	if op == Add {
 		conf.AddFulcioRoot(ctx, root.ChainPEM)
 	} else {

--- a/cmd/ctlog/managefulcio/main.go
+++ b/cmd/ctlog/managefulcio/main.go
@@ -1,0 +1,174 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	fulcioclient "github.com/sigstore/fulcio/pkg/api"
+	"github.com/sigstore/scaffolding/pkg/ctlog"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
+	"sigs.k8s.io/release-utils/version"
+)
+
+const (
+	// Key in the configmap holding the value of the tree.
+	treeKey   = "treeID"
+	configKey = "config"
+	bitSize   = 4096
+)
+
+var (
+	cmname           = flag.String("configmap", "ctlog-config", "Name of the configmap where the treeID lives. if configInSecret is false, ctlog config gets added here also.")
+	configInSecret   = flag.Bool("config-in-secret", false, "If set to true, fetch / update the ctlog configuration proto into a secret specified in ctlog-secrets under key 'config'.")
+	secretName       = flag.String("secret", "ctlog-secrets", "Name of the secret to fetch private key for CTLog.")
+	pubKeySecretName = flag.String("pubkeysecret", "ctlog-public-key", "Name of the secret to fetch public key from.")
+	fulcioURL        = flag.String("fulcio-url", "http://fulcio.fulcio-system.svc", "Where to fetch the fulcio Root CA from.")
+	operation        = flag.String("operation", "", "Operation to perform for the specified fulcio [add,remove]")
+)
+
+type fulcioOp string
+
+const (
+	Add    fulcioOp = "ADD"
+	Remove fulcioOp = "REMOVE"
+)
+
+func main() {
+	flag.Parse()
+	ns := os.Getenv("NAMESPACE")
+	if ns == "" {
+		panic("env variable NAMESPACE must be set")
+	}
+
+	ctx := signals.NewContext()
+
+	var op fulcioOp
+	switch fulcioOperation := *operation; fulcioOperation {
+	case "add":
+		op = Add
+	case "remove":
+		op = Remove
+	default:
+		logging.FromContext(ctx).Fatalf("No operation given, use --operation with [add,remove]")
+	}
+
+	versionInfo := version.GetVersionInfo()
+	logging.FromContext(ctx).Infof("running managefulcio Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+
+	logging.FromContext(ctx).Infof("%sing %s", op, *fulcioURL)
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logging.FromContext(ctx).Panicf("Failed to get InClusterConfig: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logging.FromContext(ctx).Panicf("Failed to get clientset: %v", err)
+	}
+
+	// Fetch the fulcio Root CA
+	u, err := url.Parse(*fulcioURL)
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Invalid fulcioURL %s : %v", *fulcioURL, err)
+	}
+	client := fulcioclient.NewClient(u)
+	root, err := client.RootCert()
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to fetch fulcio Root cert: %w", err)
+	}
+
+	logging.FromContext(ctx).Infof("Fulcio Root is: %+v", root)
+	current := map[string][]byte{}
+	nsSecret := clientset.CoreV1().Secrets(ns)
+	secrets, err := nsSecret.Get(ctx, *secretName, metav1.GetOptions{})
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to get secret: %s/%s : %v", ns, *secretName, err)
+	}
+	current["private"] = secrets.Data["private"]
+	current["public"] = secrets.Data["public"]
+	current["rootca"] = secrets.Data["rootca"]
+	for k, v := range secrets.Data {
+		if strings.HasPrefix(k, "fulcio-") {
+			current[k] = v
+		}
+	}
+	// If the config is stored in the secret, we don't need to deal with the
+	// configmap.
+	var cm *corev1.ConfigMap
+	if !*configInSecret {
+		var err error
+		cm, err = clientset.CoreV1().ConfigMaps(ns).Get(ctx, *cmname, metav1.GetOptions{})
+		if err != nil {
+			logging.FromContext(ctx).Panicf("Failed to get the configmap %s/%s: %v", ns, *cmname, err)
+		}
+		if cm.BinaryData == nil || cm.BinaryData[configKey] == nil {
+			logging.FromContext(ctx).Fatalf("Configmap does not hold existing configmap %s/%s: %v", ns, *cmname, err)
+		}
+		current[configKey] = cm.BinaryData[configKey]
+	} else {
+		current[configKey] = secrets.Data[configKey]
+	}
+
+	conf, err := ctlog.Unmarshal(ctx, current)
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to unmarshal: %s", err)
+	}
+	logging.FromContext(ctx).Infof("Current Config:\n%s", conf.String())
+	if op == Add {
+		conf.AddFulcioRoot(ctx, root.ChainPEM)
+	} else {
+		conf.RemoveFulcioRoot(ctx, root.ChainPEM)
+	}
+
+	// Marshal it and update configuration
+	newConfig, err := conf.MarshalConfig(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to marshal config: %v", err)
+	}
+	if !*configInSecret {
+		cm.BinaryData[configKey] = newConfig[configKey]
+		cm, err = clientset.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Failed to update configmap %s/%s: %v", ns, *cmname, err)
+		}
+	}
+
+	// Update the secret with the information
+	secrets.Data = newConfig
+	if _, err := nsSecret.Update(ctx, secrets, metav1.UpdateOptions{}); err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to udpate secret %s/%s: %v", ns, *secretName, err)
+	}
+	logging.FromContext(ctx).Infof("Config updated")
+}
+
+func mustMarshalAny(pb proto.Message) *anypb.Any {
+	ret, err := anypb.New(pb)
+	if err != nil {
+		panic(fmt.Sprintf("MarshalAny failed: %v", err))
+	}
+	return ret
+}

--- a/cmd/ctlog/verifyfulcio/main.go
+++ b/cmd/ctlog/verifyfulcio/main.go
@@ -1,0 +1,136 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	fulcioclient "github.com/sigstore/fulcio/pkg/api"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
+)
+
+type fulcios []string
+
+func (f *fulcios) String() string {
+	return fmt.Sprint(*f)
+}
+
+func (f *fulcios) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+var fulcioList fulcios
+
+type CertResponse struct {
+	Certificates []string `json:"certificates"`
+}
+
+func main() {
+
+	flag.Var(&fulcioList, "fulcio", "List of fulcios which must be in the list")
+	var ctlogURL = flag.String("ctlog-url", "ctlog.ctlog-system.svc", "CTLog to check Fulcios against.")
+	var ctlogPrefix = flag.String("log-prefix", "sigstorescaffolding", "Prefix to append to the gtlogURL url. This is basically the name of the log.")
+	flag.Parse()
+	var strictMatch = flag.Bool("strict", true, "If set to true ctlog must only contain the Fulcios in the list, no more, no less")
+	ctx := signals.NewContext()
+	fulcioURLs := make([]*url.URL, 0, len(fulcioList))
+	for _, f := range fulcioList {
+		u, err := url.Parse(f)
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Invalid fulcioURL %s : %v", f, err)
+		}
+		fulcioURLs = append(fulcioURLs, u)
+	}
+	fmt.Printf("GOT: %s\n", fulcioList.String())
+
+	// First grab the certs that CTLog has.
+	ctlog := fmt.Sprintf("%s/%s/ct/v1/get-roots", *ctlogURL, *ctlogPrefix)
+	ctlogResponse, err := http.Get(ctlog)
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to get trusted certs from ctlog: %v", err)
+	}
+	defer ctlogResponse.Body.Close()
+	body, err := io.ReadAll(ctlogResponse.Body)
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to read body from ctlog: %v", err)
+	}
+	certs := CertResponse{}
+	if err := json.Unmarshal(body, &certs); err != nil {
+		logging.FromContext(ctx).Fatalf("Failed to unmarshal body from ctlog: %v", err)
+	}
+	for i, cert := range certs.Certificates {
+		logging.FromContext(ctx).Infof("Got back cert %d: %s", i, cert)
+	}
+
+	// Keep track of certs found. Same index as fulcioURLs
+	certsFound := make([]bool, len(fulcioURLs))
+	for i, fulcio := range fulcioURLs {
+		logging.FromContext(ctx).Infof("Fetching fulcio cert %s", fulcio)
+		client := fulcioclient.NewClient(fulcio)
+		root, err := client.RootCert()
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Failed to fetch fulcio Root %s cert: %v", fulcio.String(), err)
+		}
+		fulcioCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(root.ChainPEM)
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Failed to unmarshal fulcio Root cert %s cert: %v", fulcio.String(), err)
+		}
+		fulcioRoot, err := cryptoutils.MarshalCertificateToPEM(fulcioCerts[len(fulcioCerts)-1])
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Failed to marshal fulcio Root cert %s cert: %w", fulcio.String(), err)
+		}
+		logging.FromContext(ctx).Infof("Got a root cert for fulcio Root cert %s", fulcio)
+		// Strip the certificate begin/end marker strings since CTLog doesn't
+		// have those.
+		block, _ := pem.Decode(fulcioRoot)
+		if err != nil {
+			logging.FromContext(ctx).Fatalf("Failed to decode fulcio Root PEM %s cert: %w", fulcio.String(), err)
+		}
+		fulcioRootPEM := []byte(base64.StdEncoding.EncodeToString(block.Bytes))
+		for j := range certs.Certificates {
+			logging.FromContext(ctx).Infof("Checking ctlog root cert %s", certs.Certificates[j])
+			if bytes.Compare(fulcioRootPEM, []byte(certs.Certificates[j])) == 0 {
+				logging.FromContext(ctx).Infof("Found a matching root cert for fulcio Root cert %s cert: %w", fulcio.String(), err)
+				certsFound[i] = true
+			}
+		}
+	}
+	// Check that all the expected roots were found.
+	allFound := true
+	for i := range certsFound {
+		if !certsFound[i] {
+			logging.FromContext(ctx).Errorf("Did not find a cert for %s", fulcioURLs[i])
+			allFound = false
+		}
+	}
+	if !allFound {
+		logging.FromContext(ctx).Fatal("Did not find all expected certs")
+	}
+	// If strict is on, make sure there are no more than expected.
+	if *strictMatch && len(certs.Certificates) != len(fulcioURLs) {
+		logging.FromContext(ctx).Fatalf("strict mode is on, and CTLog has %d entries and we wanted %d Fulcio entries", len(certs.Certificates), len(certsFound))
+	}
+}

--- a/config/ctlog/ctlog/300-ctlog.yaml
+++ b/config/ctlog/ctlog/300-ctlog.yaml
@@ -22,15 +22,12 @@ spec:
           image: ko://github.com/google/certificate-transparency-go/trillian/ctfe/ct_server
           args: [
             "--http_endpoint=0.0.0.0:6962",
-            "--log_config=/ctfe-config/ct_server.cfg",
+            "--log_config=/ctfe-keys/config",
             "--alsologtostderr"
           ]
           volumeMounts:
           - name: keys
             mountPath: "/ctfe-keys"
-            readOnly: true
-          - name: config
-            mountPath: "/ctfe-config"
             readOnly: true
           ports:
           - containerPort: 6962
@@ -38,16 +35,3 @@ spec:
         - name: keys
           secret:
             secretName: ctlog-secret
-            items:
-            - key: private
-              path: privkey.pem
-            - key: public
-              path: pubkey.pem
-            - key: rootca
-              path: roots.pem
-        - name: config
-          configMap:
-            name: ctlog-config
-            items:
-            - key: config
-              path: ct_server.cfg

--- a/pkg/ctlog/config_test.go
+++ b/pkg/ctlog/config_test.go
@@ -152,7 +152,7 @@ func TestRoundTrip(t *testing.T) {
 			LogID:           2022,
 			LogPrefix:       "2022-ctlog",
 		}
-		configIn.FulcioCerts = append(configIn.FulcioCerts, []byte(existingRootCert))
+		configIn.AddFulcioRoot(context.Background(), []byte(existingRootCert))
 
 		marshaledConfig, err := configIn.MarshalConfig(context.Background())
 		if err != nil {

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -17,6 +17,7 @@ package secret
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -34,8 +35,7 @@ import (
 func ReconcileSecret(ctx context.Context, name, ns string, data map[string][]byte, nsSecret v1.SecretInterface) error {
 	existingSecret, err := nsSecret.Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !apierrs.IsNotFound(err) {
-		logging.FromContext(ctx).Errorf("Failed to get secret %s/%s: %v", ns, name, err)
-		return err
+		return fmt.Errorf("failed to get secret %s/%s: %v", ns, name, err)
 	}
 
 	// If we found the secret, just make sure all the fields are there.
@@ -51,7 +51,7 @@ func ReconcileSecret(ctx context.Context, name, ns string, data map[string][]byt
 			existingSecret.Data = data
 			_, err = nsSecret.Update(ctx, existingSecret, metav1.UpdateOptions{})
 			if err != nil {
-				logging.FromContext(ctx).Errorf("Failed to update secret %s/%s: %v", ns, name, err)
+				return fmt.Errorf("failed to udpate secret %s/%s: %w", ns, name, err)
 			}
 			logging.FromContext(ctx).Infof("Updated secret %s/%s", ns, name)
 		}
@@ -65,8 +65,7 @@ func ReconcileSecret(ctx context.Context, name, ns string, data map[string][]byt
 		}
 		_, err = nsSecret.Create(ctx, secret, metav1.CreateOptions{})
 		if err != nil {
-			logging.FromContext(ctx).Errorf("Failed to create secret %s/%s: %v", ns, name, err)
-			return err
+			return fmt.Errorf("failed to create secret %s/%s: %w", ns, name, err)
 		}
 		logging.FromContext(ctx).Infof("Created secret %s/%s", ns, name)
 	}

--- a/testdata/config/add-new-fulcio/300-add-fulcio.yaml
+++ b/testdata/config/add-new-fulcio/300-add-fulcio.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: add-fulcio
+  namespace: ctlog-system
+spec:
+  # This number looks crazy, but on k8s 1.23 there does not seem to be
+  # exponential backoff, so just keep on trying. For any other version
+  # won't run this far by any chance. Also with activeDeadlineSeconds we're
+  # capping this to 5 minutes.
+  backoffLimit: 90
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      serviceAccountName: createctconfig
+      restartPolicy: Never
+      automountServiceAccountToken: true
+      containers:
+      - name: managefulcio
+        image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managefulcio
+        args: [
+          "--configmap=ctlog-config",
+          "--secret=ctlog-secret",
+          "--fulcio-url=http://fulcio-new.fulcio-system.svc",
+          "--operation=add",
+          "--config-in-secret=true"
+        ]
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/testdata/config/add-new-fulcio/300-add-fulcio.yaml
+++ b/testdata/config/add-new-fulcio/300-add-fulcio.yaml
@@ -18,8 +18,8 @@ spec:
       restartPolicy: Never
       automountServiceAccountToken: true
       containers:
-      - name: managefulcio
-        image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managefulcio
+      - name: managectroots
+        image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managectroots
         args: [
           "--configmap=ctlog-config",
           "--secret=ctlog-secret",

--- a/testdata/config/new-fulcio/certs/300-createcerts.yaml
+++ b/testdata/config/new-fulcio/certs/300-createcerts.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: createcerts-new
+  namespace: fulcio-system
+spec:
+  # This number looks crazy, but on k8s 1.23 there does not seem to be
+  # exponential backoff, so just keep on trying. For any other version
+  # won't run this far by any chance. Also with activeDeadlineSeconds we're
+  # capping this to 5 minutes.
+  backoffLimit: 90
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      serviceAccountName: createcerts
+      restartPolicy: Never
+      automountServiceAccountToken: true
+      containers:
+      - name: createcerts
+        image: ko://github.com/sigstore/scaffolding/cmd/fulcio/createcerts
+        args: [
+          "--secret=fulcio-secret-new"
+        ]
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/testdata/config/new-fulcio/fulcio/300-fulcio.yaml
+++ b/testdata/config/new-fulcio/fulcio/300-fulcio.yaml
@@ -1,0 +1,68 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: fulcio-system
+  name: fulcio-new
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
+    spec:
+      serviceAccountName: fulcio
+      # This doesn't actually use Kubernetes credentials, so don't mount them in.
+      automountServiceAccountToken: false
+      containers:
+      - image: gcr.io/projectsigstore/fulcio@sha256:61081295a8f75ed7537b5d1f8c7320e078dc00e4562c0bf605fbefa062c690de # v0.5.3
+        name: fulcio
+        ports:
+        - containerPort: 5555
+        args:
+          - "serve"
+          - "--port=5555"
+          - "--ca=fileca"
+          - "--fileca-key"
+          - "/var/run/fulcio-secrets/key.pem"
+          - "--fileca-cert"
+          - "/var/run/fulcio-secrets/cert.pem"
+          - "--fileca-key-passwd"
+          - "$(PASSWORD)"
+          - "--ct-log-url=http://ctlog.ctlog-system.svc/sigstorescaffolding"
+        env:
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: fulcio-secret-new
+              key: password
+        # Force a native go address resolution.
+        - name: GODEBUG
+          value: "netdns=go"
+        volumeMounts:
+        - name: fulcio-config
+          mountPath: /etc/fulcio-config
+        - name: oidc-info
+          mountPath: /var/run/fulcio
+        - name: fulcio-cert
+          mountPath: "/var/run/fulcio-secrets"
+          readOnly: true
+      volumes:
+      - name: fulcio-config
+        configMap:
+          name: fulcio-config
+      - name: fulcio-cert
+        secret:
+          secretName: fulcio-secret-new
+          items:
+          - key: private
+            path: key.pem
+          - key: cert
+            path: cert.pem
+      - name: oidc-info
+        projected:
+          sources:
+            - configMap:
+                name: kube-root-ca.crt
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                  mode: 0666

--- a/testdata/config/remove-old-fulcio/300-remove-fulcio.yaml
+++ b/testdata/config/remove-old-fulcio/300-remove-fulcio.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: createctconfig
+  name: remove-fulcio
   namespace: ctlog-system
 spec:
   # This number looks crazy, but on k8s 1.23 there does not seem to be
@@ -18,11 +18,14 @@ spec:
       restartPolicy: Never
       automountServiceAccountToken: true
       containers:
-      - name: createctconfig
+      - name: managefulcio
         image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managefulcio
         args: [
           "--configmap=ctlog-config",
-          "--secret=ctlog-secret"
+          "--secret=ctlog-secret",
+          "--fulcio-url=http://fulcio.fulcio-system.svc",
+          "--operation=remove",
+          "--config-in-secret=true"
         ]
         env:
           - name: NAMESPACE

--- a/testdata/config/remove-old-fulcio/300-remove-fulcio.yaml
+++ b/testdata/config/remove-old-fulcio/300-remove-fulcio.yaml
@@ -18,8 +18,8 @@ spec:
       restartPolicy: Never
       automountServiceAccountToken: true
       containers:
-      - name: managefulcio
-        image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managefulcio
+      - name: managectroots
+        image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managectroots
         args: [
           "--configmap=ctlog-config",
           "--secret=ctlog-secret",

--- a/testdata/config/remove-old-fulcio/300-remove-fulcio.yaml
+++ b/testdata/config/remove-old-fulcio/300-remove-fulcio.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: createctconfig
+  namespace: ctlog-system
+spec:
+  # This number looks crazy, but on k8s 1.23 there does not seem to be
+  # exponential backoff, so just keep on trying. For any other version
+  # won't run this far by any chance. Also with activeDeadlineSeconds we're
+  # capping this to 5 minutes.
+  backoffLimit: 90
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      serviceAccountName: createctconfig
+      restartPolicy: Never
+      automountServiceAccountToken: true
+      containers:
+      - name: createctconfig
+        image: ko://github.com/sigstore/scaffolding/cmd/ctlog/managefulcio
+        args: [
+          "--configmap=ctlog-config",
+          "--secret=ctlog-secret"
+        ]
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

#### Summary
* Rework the ctlog create config job to use the new pkg/ctlog package.
* Add managectroots job that can be used to add / delete Fulcio (or other) root certs for a given CTLog. Fixes #292 
* Add e2e tests for rotating Fulcio key. Adds a new one, verifies both are there, then removes another one.
* Always add the CTLog config into a secret. See #129 for discussion and motivation
* Create ecdsa key for CTLog by default as suggested by @haydentherapper 
* Rejigger the README to put things in the correct order.

Addresses but does not fix: https://github.com/sigstore/public-good-instance/issues/524

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes
* Write all the information that CTLog needs into a single secret (was previously split between a configmap/secret).
* Add multi fulcio support into CTLog.

WIP: Working on getting the e2e tests finished.

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->