### PR TITLE
Make tuf generic in prep for more fulcio / ctlog certs/keys.

### DIFF
--- a/cmd/tuf/createsecret/main.go
+++ b/cmd/tuf/createsecret/main.go
@@ -36,9 +36,12 @@ const (
 
 	// These are the fields we create in the secret specified with the
 	// --secret-name flag.
-	fulcioSecretKeyOut = "fulcio-cert"
-	ctSecretKeyOut     = "ctlog-pubkey"
-	rekorSecretKeyOut  = "rekor-pubkey"
+	// These are the target names that are created, so the field names
+	// are the names of the files that then get mounted onto the container, so
+	// we can then just slurp them in and create TUF root out of.
+	fulcioSecretKeyOut = "fulcio_v1.crt.pem"
+	ctSecretKeyOut     = "ctfe.pub"
+	rekorSecretKeyOut  = "rekor.pub"
 )
 
 var (
@@ -59,7 +62,7 @@ func main() {
 	ctx := signals.NewContext()
 
 	versionInfo := version.GetVersionInfo()
-	logging.FromContext(ctx).Infof("running create_secrets Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
+	logging.FromContext(ctx).Infof("running createsecret Version: %s GitCommit: %s BuildDate: %s", versionInfo.GitVersion, versionInfo.GitCommit, versionInfo.BuildDate)
 
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/cmd/tuf/server/main.go
+++ b/cmd/tuf/server/main.go
@@ -62,14 +62,17 @@ func main() {
 	if err != nil {
 		logging.FromContext(ctx).Fatalf("failed to read dir %s: %v", *dir, err)
 	}
-	for _, file := range tufFiles {
-		logging.FromContext(ctx).Infof("Have file %s", file.Name())
-	}
 	trimDir := strings.TrimSuffix(*dir, "/")
 	files := map[string][]byte{}
 	for _, file := range tufFiles {
 		if !file.IsDir() {
 			logging.FromContext(ctx).Infof("Got file %s", file.Name())
+			// Kubernetes adds some extra files here that are prefixed with
+			// .., for example '..data' so skip those.
+			if strings.HasPrefix(file.Name(), "..") {
+				logging.FromContext(ctx).Infof("Skipping .. file %s", file.Name())
+				continue
+			}
 			fileName := fmt.Sprintf("%s/%s", trimDir, file.Name())
 			fileBytes, err := os.ReadFile(fileName)
 			if err != nil {

--- a/cmd/tuf/server/main.go
+++ b/cmd/tuf/server/main.go
@@ -62,6 +62,9 @@ func main() {
 	if err != nil {
 		logging.FromContext(ctx).Fatalf("failed to read dir %s: %v", *dir, err)
 	}
+	for _, file := range tufFiles {
+		logging.FromContext(ctx).Infof("Have file %s", file.Name())
+	}
 	trimDir := strings.TrimSuffix(*dir, "/")
 	files := map[string][]byte{}
 	for _, file := range tufFiles {

--- a/config/tuf/server/400-service.yaml
+++ b/config/tuf/server/400-service.yaml
@@ -20,6 +20,9 @@ spec:
       containers:
       - image: ko://github.com/sigstore/scaffolding/cmd/tuf/server
         name: tuf
+        args: [
+          "--file-dir=/var/run/tuf-secrets",
+        ]
         ports:
         - containerPort: 8080 # tuf remote repo service
         env:
@@ -35,10 +38,3 @@ spec:
       - name: tuf-secrets
         secret:
           secretName: tuf-secrets
-          items:
-          - key: rekor-pubkey
-            path: rekor-pubkey
-          - key: fulcio-cert
-            path: fulcio-cert
-          - key: ctlog-pubkey
-            path: ctlog-pubkey

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -16,6 +16,7 @@ package repo
 
 import (
 	"context"
+	"os"
 	"testing"
 )
 
@@ -56,10 +57,16 @@ N6mY2prOeaBRV2dnsJzC94hOxkM5pSp9nbAK1TBOI45fOOPsH2rSR++HrA==
 )
 
 func TestCreateRepo(t *testing.T) {
-	repo, _, err := CreateRepo(context.Background(), []byte(fulcioRootCert), []byte(rekorPublicKey), []byte(ctlogPublicKey))
+	files := map[string][]byte{
+		"fulcio_v1.crt.pem": []byte(fulcioRootCert),
+		"ctfe.pub":          []byte(ctlogPublicKey),
+		"rekor.pub":         []byte(rekorPublicKey),
+	}
+	repo, dir, err := CreateRepo(context.Background(), files)
 	if err != nil {
 		t.Fatalf("Failed to CreateRepo: %s", err)
 	}
+	defer os.RemoveAll(dir)
 	meta, err := repo.GetMeta()
 	if err != nil {
 		t.Errorf("Failed to GetMeta: %s", err)


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
In preparation to be able to support more information than the hard coded fulcio,rekor,ctlog make
the TUF code more generic.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->