### PR TITLE
Close the httpresponse.Body

### DIFF
--- a/cmd/prober/write.go
+++ b/cmd/prober/write.go
@@ -120,6 +120,7 @@ func rekorWriteEndpoint(ctx context.Context) error {
 	// Export data to prometheus
 	exportDataToPrometheus(resp, rekorURL, endpoint, POST, latency)
 
+	defer resp.Body.Close()
 	body, _ = io.ReadAll(resp.Body)
 	fmt.Println(string(body))
 	return nil


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
@var-sdk noticed that we seem to be leaking memory, and it looks like we're not closing the body, so this should help with that.

#### Release Note
Fix: resource leak in the write prober for not closing the httpresponse.Body

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->