### PR TITLE
enable requesting a specific external IPv4 address

### DIFF
--- a/terraform/gcp/modules/ctlog/main.tf
+++ b/terraform/gcp/modules/ctlog/main.tf
@@ -36,5 +36,5 @@ resource "google_dns_record_set" "A_ctfe" {
   project      = var.project_id
   managed_zone = var.dns_zone_name
 
-  rrdatas = [var.load_balancer_ip]
+  rrdatas = [var.load_balancer_ipv4]
 }

--- a/terraform/gcp/modules/ctlog/variables.tf
+++ b/terraform/gcp/modules/ctlog/variables.tf
@@ -33,7 +33,7 @@ variable "dns_domain_name" {
   type        = string
 }
 
-variable "load_balancer_ip" {
-  description = "IP adddress of external load balancer"
+variable "load_balancer_ipv4" {
+  description = "IPv4 adddress of external load balancer"
   type        = string
 }

--- a/terraform/gcp/modules/dex/main.tf
+++ b/terraform/gcp/modules/dex/main.tf
@@ -36,5 +36,5 @@ resource "google_dns_record_set" "A_dex" {
   project      = var.project_id
   managed_zone = var.dns_zone_name
 
-  rrdatas = [var.load_balancer_ip]
+  rrdatas = [var.load_balancer_ipv4]
 }

--- a/terraform/gcp/modules/dex/variables.tf
+++ b/terraform/gcp/modules/dex/variables.tf
@@ -33,7 +33,7 @@ variable "dns_domain_name" {
   type        = string
 }
 
-variable "load_balancer_ip" {
-  description = "IP adddress of external load balancer"
+variable "load_balancer_ipv4" {
+  description = "IPv4 adddress of external load balancer"
   type        = string
 }

--- a/terraform/gcp/modules/fulcio/fulcio.tf
+++ b/terraform/gcp/modules/fulcio/fulcio.tf
@@ -35,7 +35,7 @@ resource "google_dns_record_set" "A_fulcio" {
   project      = var.project_id
   managed_zone = var.dns_zone_name
 
-  rrdatas = [var.load_balancer_ip]
+  rrdatas = [var.load_balancer_ipv4]
 }
 
 resource "google_dns_record_set" "A_v1_fulcio" {
@@ -46,5 +46,5 @@ resource "google_dns_record_set" "A_v1_fulcio" {
   project      = var.project_id
   managed_zone = var.dns_zone_name
 
-  rrdatas = [var.load_balancer_ip]
+  rrdatas = [var.load_balancer_ipv4]
 }

--- a/terraform/gcp/modules/fulcio/variables.tf
+++ b/terraform/gcp/modules/fulcio/variables.tf
@@ -80,7 +80,7 @@ variable "dns_domain_name" {
   type        = string
 }
 
-variable "load_balancer_ip" {
-  description = "IP adddress of external load balancer"
+variable "load_balancer_ipv4" {
+  description = "IPv4 adddress of external load balancer"
   type        = string
 }

--- a/terraform/gcp/modules/network/network.tf
+++ b/terraform/gcp/modules/network/network.tf
@@ -114,9 +114,10 @@ resource "google_compute_router_nat" "nat" {
   depends_on = [google_compute_subnetwork.subnetwork]
 }
 
-// Create a static IP for the external L7 load balancer
-resource "google_compute_global_address" "default" {
+// Create a static IP for the external IPV4 L7 load balancer
+resource "google_compute_global_address" "default_ipv4" {
   name         = format("%s-ext-lb", var.cluster_name)
+  address      = var.requested_external_ipv4_address
   address_type = "EXTERNAL"
   ip_version   = "IPV4"
   project      = var.project_id

--- a/terraform/gcp/modules/network/outputs.tf
+++ b/terraform/gcp/modules/network/outputs.tf
@@ -30,10 +30,10 @@ output "secondary_ip_range" {
   value = google_compute_subnetwork.subnetwork.secondary_ip_range
 }
 
-output "external_ip_name" {
-  value = google_compute_global_address.default.name
+output "external_ipv4_name" {
+  value = google_compute_global_address.default_ipv4.name
 }
 
-output "external_ip_address" {
-  value = google_compute_global_address.default.address
+output "external_ipv4_address" {
+  value = google_compute_global_address.default_ipv4.address
 }

--- a/terraform/gcp/modules/network/variables.tf
+++ b/terraform/gcp/modules/network/variables.tf
@@ -37,4 +37,5 @@ variable "cluster_name" {
 variable "requested_external_ipv4_address" {
   type        = string
   description = "External IPv4 address to request"
+  default     = ""
 }

--- a/terraform/gcp/modules/network/variables.tf
+++ b/terraform/gcp/modules/network/variables.tf
@@ -33,3 +33,8 @@ variable "cluster_name" {
   type    = string
   default = ""
 }
+
+variable "requested_external_ipv4_address" {
+  type        = string
+  description = "External IPv4 address to request"
+}

--- a/terraform/gcp/modules/rekor/rekor.tf
+++ b/terraform/gcp/modules/rekor/rekor.tf
@@ -50,7 +50,7 @@ resource "google_dns_record_set" "A_rekor" {
   project      = var.project_id
   managed_zone = var.dns_zone_name
 
-  rrdatas = [var.load_balancer_ip]
+  rrdatas = [var.load_balancer_ipv4]
 }
 
 // api.$dns_domain_name was a previous reference for rekor early on, and may be used by some clients

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -85,7 +85,7 @@ variable "dns_domain_name" {
   type        = string
 }
 
-variable "load_balancer_ip" {
-  description = "IP adddress of external load balancer"
+variable "load_balancer_ipv4" {
+  description = "IPv4 adddress of external load balancer"
   type        = string
 }

--- a/terraform/gcp/modules/sigstore/outputs.tf
+++ b/terraform/gcp/modules/sigstore/outputs.tf
@@ -91,12 +91,12 @@ output "bastion_kubectl" {
   value       = "HTTPS_PROXY=socks5://localhost:8118 kubectl get pods --all-namespaces"
 }
 
-output "external_ip_name" {
-  description = "Name of the external IP for services on the cluster"
-  value       = module.network.external_ip_name
+output "external_ipv4_name" {
+  description = "Name of the external IPv4 address resource for services on the cluster"
+  value       = module.network.external_ipv4_name
 }
 
-output "external_ip_address" {
-  description = "External IP Address for services on the cluster"
-  value       = module.network.external_ip_address
+output "external_ipv4_address" {
+  description = "External IPv4 Address for services on the cluster"
+  value       = module.network.external_ipv4_address
 }

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -188,9 +188,9 @@ module "rekor" {
   attestation_region = var.attestation_region == "" ? var.region : var.attestation_region
   storage_class      = var.attestation_storage_class
 
-  dns_zone_name    = var.dns_zone_name
-  dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ipv4_address
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  load_balancer_ipv4 = module.network.external_ipv4_address
 
   depends_on = [
     module.network,
@@ -214,9 +214,9 @@ module "fulcio" {
   fulcio_keyring_name = var.fulcio_keyring_name
   fulcio_key_name     = var.fulcio_intermediate_key_name
 
-  dns_zone_name    = var.dns_zone_name
-  dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ipv4_address
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  load_balancer_ipv4 = module.network.external_ipv4_address
 
   depends_on = [
     module.gke-cluster,
@@ -271,9 +271,9 @@ module "ctlog" {
 
   project_id = var.project_id
 
-  dns_zone_name    = var.dns_zone_name
-  dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ipv4_address
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  load_balancer_ipv4 = module.network.external_ipv4_address
 
   depends_on = [
     module.gke-cluster,
@@ -287,9 +287,9 @@ module "dex" {
 
   project_id = var.project_id
 
-  dns_zone_name    = var.dns_zone_name
-  dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ipv4_address
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  load_balancer_ipv4 = module.network.external_ipv4_address
 
   depends_on = [
     module.gke-cluster,

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -22,6 +22,8 @@ module "network" {
   project_id = var.project_id
 
   cluster_name = var.cluster_name
+
+  requested_external_ipv4_address = var.static_external_ipv4_address
 }
 
 // Bastion
@@ -188,7 +190,7 @@ module "rekor" {
 
   dns_zone_name    = var.dns_zone_name
   dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ip_address
+  load_balancer_ip = module.network.external_ipv4_address
 
   depends_on = [
     module.network,
@@ -214,7 +216,7 @@ module "fulcio" {
 
   dns_zone_name    = var.dns_zone_name
   dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ip_address
+  load_balancer_ip = module.network.external_ipv4_address
 
   depends_on = [
     module.gke-cluster,
@@ -271,7 +273,7 @@ module "ctlog" {
 
   dns_zone_name    = var.dns_zone_name
   dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ip_address
+  load_balancer_ip = module.network.external_ipv4_address
 
   depends_on = [
     module.gke-cluster,
@@ -287,7 +289,7 @@ module "dex" {
 
   dns_zone_name    = var.dns_zone_name
   dns_domain_name  = var.dns_domain_name
-  load_balancer_ip = module.network.external_ip_address
+  load_balancer_ip = module.network.external_ipv4_address
 
   depends_on = [
     module.gke-cluster,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -241,3 +241,8 @@ variable "dns_domain_name" {
   description = "Name of DNS domain name in Google Cloud DNS"
   type        = string
 }
+
+variable "static_external_ipv4_address" {
+  description = "Static IPv4 Address to request for external services"
+  type        = string
+}

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -245,4 +245,5 @@ variable "dns_domain_name" {
 variable "static_external_ipv4_address" {
   description = "Static IPv4 Address to request for external services"
   type        = string
+  default     = ""
 }


### PR DESCRIPTION
This augments the terraform code to allow users to request a specific IPv4 address to be used for services in an instance of the cluster. If the variable is not set, a new IPv4 address will be obtained and used.

This also includes some naming changes to prepare for adding IPv6 support if that is ever desired.