### PR TITLE
Add ctlog shards that create their own Cloud SQL instances.

### DIFF
--- a/terraform/gcp/modules/ctlog/main.tf
+++ b/terraform/gcp/modules/ctlog/main.tf
@@ -38,39 +38,3 @@ resource "google_dns_record_set" "A_ctfe" {
 
   rrdatas = [var.load_balancer_ipv4]
 }
-
-// For generating random suffix into the Cloud SQL instance name.
-resource "random_id" "db_name_suffix" {
-  byte_length = 4
-}
-
-// MYSQL for this particular CTLog
-// The name of the DB Instance created should match the name of the
-// shard for the CTLog.
-module "mysql" {
-  source = "../mysql"
-
-  # Disable DB create/modifications if enable_ctlog_sql is false
-  count = var.enable_ctlog_sql ? 1 : 0
-
-  region     = var.region
-  project_id = var.project_id
-
-  cluster_name      = var.cluster_name
-  database_version  = var.mysql_db_version
-  tier              = var.mysql_tier
-  availability_type = var.mysql_availability_type
-
-  replica_zones = var.mysql_replica_zones
-  replica_tier  = var.mysql_replica_tier
-
-  network = var.network
-
-  instance_name = var.mysql_instance_name != "" ? var.mysql_instance_name : format("%s-ctlog-mysql-%s", var.cluster_name, random_id.db_name_suffix.hex)
-  db_name       = var.mysql_db_name
-
-  ipv4_enabled              = var.mysql_ipv4_enabled
-  require_ssl               = var.mysql_require_ssl
-  backup_enabled            = var.mysql_backup_enabled
-  binary_log_backup_enabled = var.mysql_binary_log_backup_enabled
-}

--- a/terraform/gcp/modules/ctlog/main.tf
+++ b/terraform/gcp/modules/ctlog/main.tf
@@ -38,3 +38,39 @@ resource "google_dns_record_set" "A_ctfe" {
 
   rrdatas = [var.load_balancer_ipv4]
 }
+
+// For generating random suffix into the Cloud SQL instance name.
+resource "random_id" "db_name_suffix" {
+  byte_length = 4
+}
+
+// MYSQL for this particular CTLog
+// The name of the DB Instance created should match the name of the
+// shard for the CTLog.
+module "mysql" {
+  source = "../mysql"
+
+  # Disable DB create/modifications if enable_ctlog_sql is false
+  count = var.enable_ctlog_sql ? 1 : 0
+
+  region     = var.region
+  project_id = var.project_id
+
+  cluster_name      = var.cluster_name
+  database_version  = var.mysql_db_version
+  tier              = var.mysql_tier
+  availability_type = var.mysql_availability_type
+
+  replica_zones = var.mysql_replica_zones
+  replica_tier  = var.mysql_replica_tier
+
+  network = var.network
+
+  instance_name = var.mysql_instance_name != "" ? var.mysql_instance_name : format("%s-ctlog-mysql-%s", var.cluster_name, random_id.db_name_suffix.hex)
+  db_name       = var.mysql_db_name
+
+  ipv4_enabled              = var.mysql_ipv4_enabled
+  require_ssl               = var.mysql_require_ssl
+  backup_enabled            = var.mysql_backup_enabled
+  binary_log_backup_enabled = var.mysql_binary_log_backup_enabled
+}

--- a/terraform/gcp/modules/ctlog/outputs.tf
+++ b/terraform/gcp/modules/ctlog/outputs.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Used when setting up the GKE cluster to talk to MySQL.
+output "ctlog_mysql_instance" {
+  description = "The generated name of the Cloud SQL instance"
+  value       = var.enable_ctlog_sql ? module.mysql.0.mysql_instance : null
+}

--- a/terraform/gcp/modules/ctlog/variables.tf
+++ b/terraform/gcp/modules/ctlog/variables.tf
@@ -37,3 +37,100 @@ variable "load_balancer_ipv4" {
   description = "IPv4 adddress of external load balancer"
   type        = string
 }
+
+variable "region" {
+  description = "The region in which to create the VPC network"
+  type        = string
+  default     = "us-west1"
+}
+
+variable "enable_ctlog_sql" {
+  description = "Enable a database module for creating/editing Cloud SQL Instance"
+  type        = bool
+  default     = false
+}
+
+// Optional values that can be overridden or appended to if desired.
+variable "cluster_name" {
+  description = "The name to give the new Kubernetes cluster."
+  type        = string
+  default     = "sigstore-staging"
+}
+
+variable "network" {
+  type        = string
+  description = "Network to connect to."
+  default     = "default"
+}
+
+variable "mysql_instance_name" {
+  type        = string
+  description = "Name for CTLog MySQL instance. If unspecified, will default to '[var.cluster-name]-ctlog-mysql-[random.suffix]'"
+  default     = ""
+}
+
+variable "mysql_db_name" {
+  type        = string
+  description = "Name for CTLog MySQL database name."
+  default     = "trillian"
+}
+
+variable "mysql_db_version" {
+  type        = string
+  description = "CTLog MySQL database version."
+  default     = "MYSQL_5_7"
+}
+
+variable "mysql_tier" {
+  type        = string
+  description = "Machine tier for CTLog MySQL instance."
+  default     = "db-n1-standard-1"
+}
+
+variable "mysql_availability_type" {
+  type        = string
+  description = "Availability tier for CTLog MySQL"
+  default     = "REGIONAL"
+}
+
+variable "mysql_replica_zones" {
+  description = "List of zones for read replicas."
+  type        = list(any)
+  default     = []
+}
+
+variable "mysql_replica_tier" {
+  type        = string
+  description = "Machine tier for CTLog MySQL replica."
+  default     = "db-n1-standard-1"
+}
+
+variable "mysql_ipv4_enabled" {
+  type        = bool
+  description = "Whether to enable ipv4 for CTLog MySQL instance."
+  default     = false
+}
+
+variable "mysql_require_ssl" {
+  type        = bool
+  description = "Whether to require ssl for CTLog MySQL instance."
+  default     = true
+}
+
+variable "mysql_backup_enabled" {
+  type        = bool
+  description = "Whether to enable backup configuration for CTLog MySQL instance."
+  default     = true
+}
+
+variable "mysql_binary_log_backup_enabled" {
+  type        = bool
+  description = "Whether to enable binary log for backup for CTLog MySQL instance."
+  default     = true
+}
+
+variable "mysql_database_version" {
+  type        = string
+  description = "CTLog MySQL database version."
+  default     = "MYSQL_5_7"
+}

--- a/terraform/gcp/modules/mysql-shard/mysql.tf
+++ b/terraform/gcp/modules/mysql-shard/mysql.tf
@@ -21,7 +21,7 @@
 
 // Access to private cluster
 resource "google_compute_global_address" "private_ip_address" {
-  name          = format("%s-%s", var.cluster_name, var.instance_name)
+  name          = format("%s-priv-ip", var.cluster_name)
   project       = var.project_id
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"

--- a/terraform/gcp/modules/mysql-shard/mysql.tf
+++ b/terraform/gcp/modules/mysql-shard/mysql.tf
@@ -28,8 +28,6 @@ resource "google_sql_database_instance" "trillian" {
   # Set to false to delete this database
   deletion_protection = var.deletion_protection
 
-  depends_on = [google_service_networking_connection.private_vpc_connection]
-
   settings {
     tier              = var.tier
     activation_policy = "ALWAYS"

--- a/terraform/gcp/modules/mysql-shard/mysql.tf
+++ b/terraform/gcp/modules/mysql-shard/mysql.tf
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# MySQL that only creates a mysql instance. Different from the ../mysql
+# which creates serviceaccounts and services, etc. New shards for fulcio/rekor
+# should use this module.
+# Forked from https://github.com/GoogleCloudPlatform/gke-private-cluster-demo/blob/master/terraform/postgres.tf
+
+// Access to private cluster
+resource "google_compute_global_address" "private_ip_address" {
+  name          = format("%s-%s", var.cluster_name, var.instance_name)
+  project       = var.project_id
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = var.network
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = var.network
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+  depends_on              = [google_compute_global_address.private_ip_address]
+}
+
+resource "google_sql_database_instance" "trillian" {
+  project          = var.project_id
+  name             = var.instance_name
+  database_version = var.database_version
+  region           = var.region
+
+  # Set to false to delete this database
+  deletion_protection = var.deletion_protection
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+
+  settings {
+    tier              = var.tier
+    activation_policy = "ALWAYS"
+    availability_type = var.availability_type
+
+    ip_configuration {
+      ipv4_enabled    = var.ipv4_enabled
+      private_network = var.network
+      require_ssl     = var.require_ssl
+    }
+
+    database_flags {
+      name  = "cloudsql_iam_authentication"
+      value = "on"
+    }
+
+    backup_configuration {
+      enabled            = var.backup_enabled
+      binary_log_enabled = var.binary_log_backup_enabled
+    }
+  }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
+}
+
+resource "google_sql_database_instance" "read_replica" {
+  for_each = toset(var.replica_zones)
+
+  name                 = "${google_sql_database_instance.trillian.name}-replica-${each.key}"
+  master_instance_name = google_sql_database_instance.trillian.name
+  region               = var.region
+  database_version     = var.database_version
+
+  replica_configuration {
+    failover_target = false
+  }
+
+  settings {
+    tier              = var.replica_tier
+    availability_type = "ZONAL"
+
+    ip_configuration {
+      ipv4_enabled    = var.ipv4_enabled
+      private_network = var.network
+      require_ssl     = var.require_ssl
+    }
+
+    database_flags {
+      name  = "cloudsql_iam_authentication"
+      value = "on"
+    }
+  }
+}
+
+resource "google_sql_database" "trillian" {
+  name       = var.db_name
+  project    = var.project_id
+  instance   = google_sql_database_instance.trillian.name
+  collation  = "utf8_general_ci"
+  depends_on = [google_sql_database_instance.trillian]
+}
+
+resource "google_sql_user" "trillian" {
+  name       = "trillian"
+  project    = var.project_id
+  instance   = google_sql_database_instance.trillian.name
+  password   = var.password
+  host       = "%"
+  depends_on = [google_sql_database_instance.trillian]
+}
+

--- a/terraform/gcp/modules/mysql-shard/mysql.tf
+++ b/terraform/gcp/modules/mysql-shard/mysql.tf
@@ -19,23 +19,6 @@
 # should use this module.
 # Forked from https://github.com/GoogleCloudPlatform/gke-private-cluster-demo/blob/master/terraform/postgres.tf
 
-// Access to private cluster
-resource "google_compute_global_address" "private_ip_address" {
-  name          = format("%s-priv-ip", var.cluster_name)
-  project       = var.project_id
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = var.network
-}
-
-resource "google_service_networking_connection" "private_vpc_connection" {
-  network                 = var.network
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
-  depends_on              = [google_compute_global_address.private_ip_address]
-}
-
 resource "google_sql_database_instance" "trillian" {
   project          = var.project_id
   name             = var.instance_name

--- a/terraform/gcp/modules/mysql-shard/outputs.tf
+++ b/terraform/gcp/modules/mysql-shard/outputs.tf
@@ -15,7 +15,26 @@
  */
 
 // Used when setting up the GKE cluster to talk to MySQL.
-output "ctlog_mysql_instance" {
+output "mysql_instance" {
   description = "The generated name of the Cloud SQL instance"
-  value       = var.enable_ctlog_sql ? module.mysql.0.mysql_instance : null
+  value       = google_sql_database_instance.trillian.name
+}
+
+// Full connection string for the MySQL DB>
+output "mysql_connection" {
+  description = "The connection string dynamically generated for storage inside the Kubernetes configmap"
+  value       = format("%s:%s:%s", var.project_id, var.region, google_sql_database_instance.trillian.name)
+}
+
+// Mysql DB username.
+output "mysql_user" {
+  description = "The Cloud SQL Instance User name"
+  value       = google_sql_user.trillian.name
+}
+
+// Mysql DB password.
+output "mysql_pass" {
+  sensitive   = true
+  description = "The Cloud SQL Instance Password (Generated)"
+  value       = google_sql_user.trillian.password
 }

--- a/terraform/gcp/modules/mysql-shard/variables.tf
+++ b/terraform/gcp/modules/mysql-shard/variables.tf
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type    = string
+  default = ""
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "Must specify project_id variable."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region"
+  default     = "us-west1"
+}
+
+variable "replica_zones" {
+  description = "List of zones for read replicas."
+  type        = list(any)
+  default     = []
+}
+
+variable "cluster_name" {
+  type    = string
+  default = ""
+}
+
+variable "tier" {
+  type        = string
+  description = "Machine tier for MySQL instance."
+  default     = "db-n1-standard-1"
+}
+
+variable "replica_tier" {
+  type        = string
+  description = "Machine tier for MySQL replica."
+  default     = "db-n1-standard-1"
+}
+
+variable "availability_type" {
+  type        = string
+  description = "Availability tier for MySQL"
+  default     = "REGIONAL"
+}
+
+variable "ipv4_enabled" {
+  type        = bool
+  description = "Whether to enable ipv4 for MySQL instance."
+  default     = false
+}
+
+variable "require_ssl" {
+  type        = bool
+  description = "Whether to require ssl for MySQL instance."
+  default     = true
+}
+
+variable "backup_enabled" {
+  type        = bool
+  description = "Whether to enable backup configuration."
+  default     = true
+}
+
+variable "binary_log_backup_enabled" {
+  type        = bool
+  description = "Whether to enable binary log for backup."
+  default     = true
+}
+
+variable "network" {
+  type    = string
+  default = "default"
+}
+
+variable "subnetwork" {
+  type    = string
+  default = "default"
+}
+
+variable "instance_name" {
+  type        = string
+  description = "Name for MySQL instance."
+}
+
+variable "db_name" {
+  type        = string
+  description = "Name for MySQL database name."
+  default     = "trillian"
+}
+
+variable "database_version" {
+  type        = string
+  description = "MySQL database version."
+  default     = "MYSQL_5_7"
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Deletion protection for MYSQL database. Must be set to false for `terraform apply` or `terraform destroy` to delete the db."
+  default     = true
+}
+
+// This is ok to have here because nobody can connect to the database without
+// IAM and it sits on private network.
+variable "password" {
+  type        = string
+  description = "mysql password within the database"
+  sensitive   = true
+}

--- a/terraform/gcp/modules/mysql-shard/versions.tf
+++ b/terraform/gcp/modules/mysql-shard/versions.tf
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  type    = string
-  default = ""
-  validation {
-    condition     = length(var.project_id) > 0
-    error_message = "Must specify project_id variable."
+terraform {
+  required_version = ">= 1.1.3, < 1.4.0"
+
+  required_providers {
+    google = {
+      version = ">= 4.11.0, < 4.38.0"
+      source  = "hashicorp/google"
+    }
+    google-beta = {
+      version = ">= 4.11.0, < 4.38.0"
+      source  = "hashicorp/google-beta"
+    }
+    random = {
+      version = ">= 3.1.0, < 3.2.0"
+      source  = "hashicorp/random"
+    }
   }
-}
-
-variable "dns_zone_name" {
-  description = "Name of DNS Zone object in Google Cloud DNS"
-  type        = string
-}
-
-variable "dns_domain_name" {
-  description = "Name of DNS domain name in Google Cloud DNS"
-  type        = string
-}
-
-variable "load_balancer_ipv4" {
-  description = "IPv4 adddress of external load balancer"
-  type        = string
 }

--- a/terraform/gcp/modules/sigstore/outputs.tf
+++ b/terraform/gcp/modules/sigstore/outputs.tf
@@ -31,6 +31,13 @@ output "mysql_instance" {
   value       = module.mysql.mysql_instance
 }
 
+// Used for setting up the GKE cluster to talk to CTLog Shard DBs.
+// Outputs a list of strings for each CTLog Cloud SQL instance.
+output "ctlog_mysql_instances" {
+  description = "Names of the DB instances created for the CTLog shards"
+  value       = [for ctlog_shard in module.ctlog_shards : ctlog_shard.ctlog_mysql_instance]
+}
+
 // Full connection string for the MySQL DB>
 output "mysql_connection" {
   description = "The connection string dynamically generated for storage inside the Kubernetes configmap"

--- a/terraform/gcp/modules/sigstore/outputs.tf
+++ b/terraform/gcp/modules/sigstore/outputs.tf
@@ -35,7 +35,7 @@ output "mysql_instance" {
 // Outputs a list of strings for each CTLog Cloud SQL instance.
 output "ctlog_mysql_instances" {
   description = "Names of the DB instances created for the CTLog shards"
-  value       = [for ctlog_shard in module.ctlog_shards : ctlog_shard.ctlog_mysql_instance]
+  value       = [for ctlog_shard in module.ctlog_shards : ctlog_shard.mysql_instance]
 }
 
 // Full connection string for the MySQL DB>

--- a/terraform/gcp/modules/sigstore/outputs.tf
+++ b/terraform/gcp/modules/sigstore/outputs.tf
@@ -31,11 +31,16 @@ output "mysql_instance" {
   value       = module.mysql.mysql_instance
 }
 
-// Used for setting up the GKE cluster to talk to CTLog Shard DBs.
 // Outputs a list of strings for each CTLog Cloud SQL instance.
 output "ctlog_mysql_instances" {
   description = "Names of the DB instances created for the CTLog shards"
   value       = [for ctlog_shard in module.ctlog_shards : ctlog_shard.mysql_instance]
+}
+
+// Outputs a list of connection strings for each CTLog Cloud SQL instance.
+output "ctlog_mysql_connections" {
+  description = "Connection strings of the DB instances created for the CTLog shards"
+  value       = [for ctlog_shard in module.ctlog_shards : ctlog_shard.mysql_connection]
 }
 
 // Full connection string for the MySQL DB>

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -310,7 +310,7 @@ module "ctlog_shards" {
 
   for_each = toset(var.ctlog_shards)
 
-  instance_name = format("ctlog-%s", each.key)
+  instance_name = format("%s-ctlog-%s", var.cluster_name, each.key)
 
   project_id = var.project_id
   region     = var.region

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -328,10 +328,11 @@ module "ctlog_shards" {
   dns_domain_name    = var.dns_domain_name
   load_balancer_ipv4 = module.network.external_ipv4_address
 
-  cluster_name            = var.cluster_name
-  mysql_database_version  = var.mysql_db_version
-  mysql_tier              = var.mysql_tier
-  mysql_availability_type = var.mysql_availability_type
+  cluster_name = var.cluster_name
+  // NB: These are commented out so that we pick up the defaults
+  // for the particular environment consistently.
+  //mysql_database_version  = var.mysql_db_version
+  //mysql_tier              = var.mysql_tier
 
   mysql_replica_zones = var.mysql_replica_zones
   mysql_replica_tier  = var.mysql_replica_tier

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -253,3 +253,9 @@ variable "static_external_ipv4_address" {
   type        = string
   default     = ""
 }
+
+variable "ctlog_shards" {
+  type        = list(string)
+  description = "Array of CTLog shards to create. Entry should be something like [2021, 2022], which would then have 2 independent CTLog shards backed by ctlog-2021 and ctlog-2022 Cloud SQL instances."
+  default     = []
+}


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

#### Summary
WIP: Need to do some testing, but wanted to share the approach early :) 

Starts putting the pieces at the infra level necessary for:
* https://github.com/sigstore/public-good-instance/issues/343
* https://github.com/sigstore/public-good-instance/issues/418
* https://github.com/sigstore/public-good-instance/issues/524

In particular:
 * Add mysql creation (optionally) into the CTLog module. It's made optional since we already use that module, and we don't
want to create a new Cloud SQL instance for the already existing one.
 * Add ctlog_shards variable to Sigstore `ctlog_shards` which is a list of shards. So we'd add, say 2021 into this list first to create a new separate Cloud SQL instance for the new CTLog
 * Add ctlog_mysql_instances which outputs the list of CTLog DB instances

#### Release Note
 * Add ability to create new CTLog shards with their own Cloud SQL instance.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->