### PR TITLE
use both google/google-beta provider. Update them to allow 4.37.x, allow terraform 1.3.x

### DIFF
--- a/terraform/gcp/modules/argocd/versions.tf
+++ b/terraform/gcp/modules/argocd/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/argocd/versions.tf
+++ b/terraform/gcp/modules/argocd/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/argocd/versions.tf
+++ b/terraform/gcp/modules/argocd/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/audit/versions.tf
+++ b/terraform/gcp/modules/audit/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
   }

--- a/terraform/gcp/modules/audit/versions.tf
+++ b/terraform/gcp/modules/audit/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/audit/versions.tf
+++ b/terraform/gcp/modules/audit/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
   }

--- a/terraform/gcp/modules/bastion/versions.tf
+++ b/terraform/gcp/modules/bastion/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/bastion/versions.tf
+++ b/terraform/gcp/modules/bastion/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/bastion/versions.tf
+++ b/terraform/gcp/modules/bastion/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/ca/versions.tf
+++ b/terraform/gcp/modules/ca/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/ca/versions.tf
+++ b/terraform/gcp/modules/ca/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/ca/versions.tf
+++ b/terraform/gcp/modules/ca/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/ctlog/versions.tf
+++ b/terraform/gcp/modules/ctlog/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/ctlog/versions.tf
+++ b/terraform/gcp/modules/ctlog/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/ctlog/versions.tf
+++ b/terraform/gcp/modules/ctlog/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/dex/versions.tf
+++ b/terraform/gcp/modules/dex/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/dex/versions.tf
+++ b/terraform/gcp/modules/dex/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/dex/versions.tf
+++ b/terraform/gcp/modules/dex/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/external_secrets/versions.tf
+++ b/terraform/gcp/modules/external_secrets/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/external_secrets/versions.tf
+++ b/terraform/gcp/modules/external_secrets/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/external_secrets/versions.tf
+++ b/terraform/gcp/modules/external_secrets/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/fulcio/versions.tf
+++ b/terraform/gcp/modules/fulcio/versions.tf
@@ -19,8 +19,8 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
       version = ">= 4.11.0, < 4.26.0"

--- a/terraform/gcp/modules/fulcio/versions.tf
+++ b/terraform/gcp/modules/fulcio/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/fulcio/versions.tf
+++ b/terraform/gcp/modules/fulcio/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {

--- a/terraform/gcp/modules/gke_cluster/versions.tf
+++ b/terraform/gcp/modules/gke_cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/gke_cluster/versions.tf
+++ b/terraform/gcp/modules/gke_cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/gke_cluster/versions.tf
+++ b/terraform/gcp/modules/gke_cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/monitoring/dex/versions.tf
+++ b/terraform/gcp/modules/monitoring/dex/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/dex/versions.tf
+++ b/terraform/gcp/modules/monitoring/dex/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/dex/versions.tf
+++ b/terraform/gcp/modules/monitoring/dex/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/monitoring/fulcio/versions.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/fulcio/versions.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/fulcio/versions.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/monitoring/infra/versions.tf
+++ b/terraform/gcp/modules/monitoring/infra/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/infra/versions.tf
+++ b/terraform/gcp/modules/monitoring/infra/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/infra/versions.tf
+++ b/terraform/gcp/modules/monitoring/infra/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/monitoring/prober/versions.tf
+++ b/terraform/gcp/modules/monitoring/prober/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/prober/versions.tf
+++ b/terraform/gcp/modules/monitoring/prober/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/prober/versions.tf
+++ b/terraform/gcp/modules/monitoring/prober/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/monitoring/rekor/versions.tf
+++ b/terraform/gcp/modules/monitoring/rekor/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/rekor/versions.tf
+++ b/terraform/gcp/modules/monitoring/rekor/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/rekor/versions.tf
+++ b/terraform/gcp/modules/monitoring/rekor/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/monitoring/versions.tf
+++ b/terraform/gcp/modules/monitoring/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/versions.tf
+++ b/terraform/gcp/modules/monitoring/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/monitoring/versions.tf
+++ b/terraform/gcp/modules/monitoring/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/mysql/versions.tf
+++ b/terraform/gcp/modules/mysql/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/mysql/versions.tf
+++ b/terraform/gcp/modules/mysql/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/mysql/versions.tf
+++ b/terraform/gcp/modules/mysql/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/network/versions.tf
+++ b/terraform/gcp/modules/network/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/network/versions.tf
+++ b/terraform/gcp/modules/network/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/network/versions.tf
+++ b/terraform/gcp/modules/network/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/oslogin/versions.tf
+++ b/terraform/gcp/modules/oslogin/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/oslogin/versions.tf
+++ b/terraform/gcp/modules/oslogin/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/oslogin/versions.tf
+++ b/terraform/gcp/modules/oslogin/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/policy_bindings/versions.tf
+++ b/terraform/gcp/modules/policy_bindings/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/policy_bindings/versions.tf
+++ b/terraform/gcp/modules/policy_bindings/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/policy_bindings/versions.tf
+++ b/terraform/gcp/modules/policy_bindings/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/redis/versions.tf
+++ b/terraform/gcp/modules/redis/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/redis/versions.tf
+++ b/terraform/gcp/modules/redis/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/redis/versions.tf
+++ b/terraform/gcp/modules/redis/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/rekor/versions.tf
+++ b/terraform/gcp/modules/rekor/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/rekor/versions.tf
+++ b/terraform/gcp/modules/rekor/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/rekor/versions.tf
+++ b/terraform/gcp/modules/rekor/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/sigstore/versions.tf
+++ b/terraform/gcp/modules/sigstore/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/sigstore/versions.tf
+++ b/terraform/gcp/modules/sigstore/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/sigstore/versions.tf
+++ b/terraform/gcp/modules/sigstore/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {

--- a/terraform/gcp/modules/tuf/versions.tf
+++ b/terraform/gcp/modules/tuf/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.37.0"
+      version = ">= 4.11.0, < 4.38.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/tuf/versions.tf
+++ b/terraform/gcp/modules/tuf/versions.tf
@@ -19,11 +19,11 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.26.0"
-      source  = "hashicorp/google-beta"
+      version = ">= 4.11.0, < 4.37.0"
+      source  = "hashicorp/google"
     }
     google-beta = {
-      version = ">= 4.11.0, < 4.26.0"
+      version = ">= 4.11.0, < 4.37.0"
       source  = "hashicorp/google-beta"
     }
     random = {

--- a/terraform/gcp/modules/tuf/versions.tf
+++ b/terraform/gcp/modules/tuf/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.3.0"
+  required_version = ">= 1.1.3, < 1.4.0"
 
   required_providers {
     google = {


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

Fixes #371 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

 * Update terraform versions to use both google and google-beta, instead of duplicating them.
 * Maybe fixes #371 (if it's a bug indeed and not just me misunderstanding something)
 * Accept Terraform version 1.3.x since it's complaining that I should upgrade.


#### Release Note
Fix #371 

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->