### PR TITLE
Set User Agent header and add prometheus metrics for prober build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ sign-release-images: sign-test-images
 .PHONY: release-images
 release-images: ko-resolve ko-resolve-testdata
 
+.PHONY: prober
+prober:
+	go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/prober
+
 ### Testing
 
 .PHONY: ko-apply

--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -145,6 +145,7 @@ func httpRequest(host string, r ReadProberCheck) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Sigstore_Scaffolding_Prober/%s", versionInfo.GitVersion))
 	q := req.URL.Query()
 	for k, v := range r.queries {
 		q.Add(k, v)

--- a/cmd/prober/prometheus.go
+++ b/cmd/prober/prometheus.go
@@ -62,3 +62,25 @@ func exportDataToPrometheus(resp *http.Response, host, endpoint, method string, 
 	fmt.Println("Status code: ", statusCode)
 	fmt.Printf("Latency for %s %s: %d\n", method, host+endpoint, latency)
 }
+
+// NewVersionCollector returns a collector that exports metrics about current version
+// information.
+func NewVersionCollector(program string) prometheus.Collector {
+	return prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: program,
+			Name:      "build_info",
+			Help: fmt.Sprintf(
+				"A metric with a constant '1' value labeled by version, revision, branch, and goversion from which %s was built.",
+				program,
+			),
+			ConstLabels: prometheus.Labels{
+				"version":    versionInfo.GitVersion,
+				"revision":   versionInfo.GitCommit,
+				"build_date": versionInfo.BuildDate,
+				"goversion":  versionInfo.GoVersion,
+			},
+		},
+		func() float64 { return 1 },
+	)
+}

--- a/cmd/prober/write.go
+++ b/cmd/prober/write.go
@@ -80,6 +80,7 @@ func fulcioWriteEndpoint(ctx context.Context) error {
 	req.Header.Set("Authorization", "Bearer "+tok)
 	// Set the content-type to reflect we're sending JSON.
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Sigstore_Scaffolding_Prober/%s", versionInfo.GitVersion))
 
 	t := time.Now()
 	resp, err := http.DefaultClient.Do(req)
@@ -109,6 +110,7 @@ func rekorWriteEndpoint(ctx context.Context) error {
 	}
 	// Set the content-type to reflect we're sending JSON.
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Sigstore_Scaffolding_Prober/%s", versionInfo.GitVersion))
 
 	t := time.Now()
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
#### Summary
- export version information to prometheus
- set user agent when doing the requests


example of the prometheus metric

```
# HELP sigstore_prober_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which sigstore_prober was built.
# TYPE sigstore_prober_build_info gauge
sigstore_prober_build_info{build_date="2022-09-21T21:16:41",goversion="go1.19.1",revision="df49efcde361792134e16e55df6fbed8090a5e77",version="v0.4.8-dirty"} 1
```

FIxes: https://github.com/sigstore/public-good-instance/issues/749
