### PR TITLE
Write the repository into secret, test air-gap mode.

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -156,6 +156,8 @@ jobs:
     - name: Initialize cosign with our custom tuf root and make root copy
       run: |
         kubectl -n tuf-system get secrets tuf-root -ojsonpath='{.data.root}' | base64 -d > ./root.json
+        # Also grab the compressed repository for airgap testing.
+        kubectl -n tuf-system get secrets tuf-root -ojsonpath='{.data.repository}'  | base64 -d > ./repository.tar.gz
         TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
         echo "TUF_MIRROR=$TUF_MIRROR" >> $GITHUB_ENV
         # Then initialize cosign
@@ -202,6 +204,30 @@ jobs:
     - name: Verify with cosign from the action using k8s token
       run: |
         cosign verify --rekor-url ${{ env.REKOR_URL }} --allow-insecure-registry ${{ env.demoimage }}
+
+    # Test with cosign in 'airgapped mode'
+    # Uncomment these once modified cosign goes in.
+    #- name: Checkout modified cosign for testing.
+    #  uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+    #  with:
+    #    repository: vaikas/cosign
+    #    ref: air-gap
+    #    path: ./src/github.com/sigstore/cosign
+    #- name: Build cosign
+    #  working-directory: ./src/github.com/sigstore/cosign
+    #  run: |
+    #    go build -o ./cosign ./cmd/cosign/main.go
+    #- name: Untar the repository from the fetched secret, initialize and verify with it
+    #  working-directory: ./src/github.com/sigstore/cosign
+    #  run: |
+    #    # Also grab the compressed repository for airgap testing.
+    #    kubectl -n tuf-system get secrets tuf-root -ojsonpath='{.data.repository}'  | base64 -d > ./repository.tar.gz
+    #    tar -zxvf ./repository.tar.gz
+    #    PWD=$(pwd)
+    #    ROOT=${PWD}/repository/1.root.json
+    #    REPOSITORY=${PWD}/repository
+    #    ./cosign initialize --root ${ROOT} --mirror file://${REPOSITORY}
+    #    ./cosign verify --rekor-url ${{ env.REKOR_URL }} --allow-insecure-registry ${{ env.demoimage }}
 
     - name: Collect diagnostics
       if: ${{ failure() }}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -15,8 +15,10 @@
 package repo
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -72,4 +74,53 @@ func TestCreateRepo(t *testing.T) {
 		t.Errorf("Failed to GetMeta: %s", err)
 	}
 	t.Logf("Got repo meta as: %+v", meta)
+}
+
+func TestCompressUncompressFS(t *testing.T) {
+	files := map[string][]byte{
+		"fulcio_v1.crt.pem": []byte(fulcioRootCert),
+		"ctfe.pub":          []byte(ctlogPublicKey),
+		"rekor.pub":         []byte(rekorPublicKey),
+	}
+	repo, dir, err := CreateRepo(context.Background(), files)
+	if err != nil {
+		t.Fatalf("Failed to CreateRepo: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	var buf bytes.Buffer
+	fsys := os.DirFS(dir)
+	if err = CompressFS(fsys, &buf, map[string]bool{"keys": true, "staged": true}); err != nil {
+		t.Fatalf("Failed to compress: %v", err)
+	}
+	os.WriteFile("/tmp/newcompressed", buf.Bytes(), os.ModePerm)
+	dstDir := t.TempDir()
+	if err = Uncompress(&buf, dstDir); err != nil {
+		t.Fatalf("Failed to uncompress: %v", err)
+	}
+	// Then check that files have been uncompressed there.
+	meta, err := repo.GetMeta()
+	if err != nil {
+		t.Errorf("Failed to GetMeta: %s", err)
+	}
+	root := meta["root.json"]
+
+	// This should have roundtripped to the new directory.
+	rtRoot, err := os.ReadFile(filepath.Join(dstDir, "repository", "root.json"))
+	if err != nil {
+		t.Errorf("Failed to read the roundtripped root %v", err)
+	}
+	if bytes.Compare(root, rtRoot) != 0 {
+		t.Errorf("Roundtripped root differs:\n%s\n%s", string(root), string(rtRoot))
+	}
+
+	// As well as, say rekor.pub under targets dir
+	rtRekor, err := os.ReadFile(filepath.Join(dstDir, "repository", "targets", "rekor.pub"))
+	if err != nil {
+		t.Errorf("Failed to read the roundtripped rekor %v", err)
+	}
+	if bytes.Compare(files["rekor.pub"], rtRekor) != 0 {
+		t.Errorf("Roundtripped rekor differs:\n%s\n%s", rekorPublicKey, string(rtRekor))
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

TUF server now writes the compressed repo to a secret along with 1.root.json. This way we can test things like air-gap modes, especially in policy-controller without env variables.
Add a test simulating air-gap mode where we bring in a filesystem based TUF repository.

Was tested with:
https://github.com/sigstore/cosign/compare/main...vaikas:cosign:air-gap?expand=1

But I uncommented it for now so we can get this in and then I can add cosign e2e tests there as well once
we cut a release here.

#### Release Note

 * TUF root writes gzipped tar of the TUF repository, suitable for testing air-gap modes.

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->