### PR TITLE
Add availability. SLO definitions to terraform for Fulcio and Rekor

### DIFF
--- a/terraform/gcp/modules/gke_cluster/outputs.tf
+++ b/terraform/gcp/modules/gke_cluster/outputs.tf
@@ -25,6 +25,11 @@ output "cluster_endpoint" {
   value       = google_container_cluster.cluster.endpoint
 }
 
+output "cluster_location" {
+  description = "Cluster location"
+  value       = google_container_cluster.cluster.location
+}
+
 output "cluster_ca_certificate" {
   sensitive   = true
   description = "Cluster ca certificate (base64 encoded)"

--- a/terraform/gcp/modules/monitoring/fulcio/slo.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/slo.tf
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "slos" {
+  source = "../slo"
+  count  = var.create_slos ? 1 : 0
+
+  project_id    = var.project_id
+  service_id    = "fulcio"
+  display_name  = "Fulcio"
+  resource_name = format("//container.googleapis.com/projects/%s/locations/%s/clusters/%s/k8s/namespaces/%s", var.project_id, var.cluster_location, var.cluster_name, var.gke_namespace)
+
+
+  availability_slos = {
+    server-availability = {
+      display_prefix            = "Availability (Server)"
+      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\" resource.type=\"prometheus_target\" resource.labels.namespace=\"%s\"", var.gke_namespace)
+      # Only count server errors.
+      # TODO: If clients can trigger DeadlineExceeded with short deadlines, reconsider this metric.
+      bad_filter = "metric.labels.grpc_method=one_of(\"DeadlineExceeded\",\"Internal\")"
+      slos = {
+        all-methods = {
+          display_suffix = "All Methods"
+          label_filter   = ""
+          goal           = 0.995
+          label_filter   = "metric.labels.grpc_service=one_of(\"dev.sigstore.fulcio.v1beta.CA\",\"dev.sigstore.fulcio.v2.CA\")"
+        },
+        v1beta-create-signing-certificate = {
+          display_suffix = "CreateSigningCertificate v1beta"
+          label_filter   = "metric.labels.grpc_service=\"dev.sigstore.fulcio.v1beta.CA\" metric.labels.grpc_method=\"CreateSigningCertificate\""
+          goal           = 0.995
+        },
+        v1beta-get-root-certificate = {
+          display_suffix = "GetRootCertificate v1beta"
+          label_filter   = "metric.labels.grpc_service=\"dev.sigstore.fulcio.v1beta.CA\" metric.labels.grpc_method=\"GetRootCertificate\""
+          goal           = 0.995
+        },
+        v2-create-signing-certificate = {
+          display_suffix = "CreateSigningCertificate v2"
+          label_filter   = "metric.labels.grpc_service=\"dev.sigstore.fulcio.v2.CA\" metric.labels.grpc_method=\"CreateSigningCertificate\""
+          goal           = 0.995
+        },
+        v2-get-configuration = {
+          display_suffix = "GetConfiguration v2"
+          label_filter   = "metric.labels.grpc_service=\"dev.sigstore.fulcio.v2.CA\" metric.labels.grpc_method=\"GetConfiguration\""
+          goal           = 0.995
+        },
+        v2-get-trust-bundle = {
+          display_suffix = "GetTrustBundle v2"
+          label_filter   = "metric.labels.grpc_service=\"dev.sigstore.fulcio.v2.CA\" metric.labels.grpc_method=\"GetTrustBundle\""
+          goal           = 0.995
+        },
+      }
+    },
+    prober-availability = {
+      display_prefix            = "Availability (Prober)"
+      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/api_endpoint_latency_count/summary\" resource.type=\"prometheus_target\" metric.labels.host=\"%s\"", var.prober_url)
+      bad_filter                = "metric.labels.status_code!=monitoring.regex.full_match(\"20[0-1]\")"
+      slos = {
+        all-methods = {
+          display_suffix = "All Methods"
+          label_filter   = ""
+          goal           = 0.995
+        },
+        v1beta-create-signing-certificate = {
+          display_suffix = "CreateSigningCertificate v1beta (/api/v1/signingCert - POST)"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/signingCert\" metric.labels.method=\"POST\""
+          goal           = 0.995
+        },
+        v1beta-get-root-certificate = {
+          display_suffix = "GetRootCertificate v1beta (/api/v1/rootCert - GET)"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/rootCert\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        v2-create-signing-certificate = {
+          display_suffix = "CreateSigningCertificate v2 (/api/v2/signingCert - POST)"
+          label_filter   = "metric.labels.endpoint=\"/api/v2/signingCert\" metric.labels.method=\"POST\""
+          goal           = 0.995
+        },
+        v2-get-configuration = {
+          display_suffix = "GetConfiguration v2 (/api/v2/configuration - GET)"
+          label_filter   = "metric.labels.endpoint=\"/api/v2/configuration\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        v2-get-trust-bundle = {
+          display_suffix = "GetTrustBundle v2 (/api/v2/trustBundle - GET)"
+          label_filter   = "metric.labels.endpoint=\"/api/v2/trustBundle\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+      }
+    }
+  }
+}

--- a/terraform/gcp/modules/monitoring/fulcio/variables.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/variables.tf
@@ -24,8 +24,8 @@ variable "project_id" {
 }
 
 variable "cluster_location" {
-  type        = string
   description = "Zone or Region to create cluster in."
+  type        = string
   default     = "us-central1"
 }
 
@@ -40,6 +40,20 @@ variable "cluster_name" {
 variable "fulcio_url" {
   description = "Fulcio URL"
   default     = "fulcio.sigstore.dev"
+}
+
+// URLs for Sigstore services
+variable "prober_url" {
+  description = "Fulcio Prober URL"
+  type        = string
+  default     = ""
+}
+
+// Namespace for monitored service
+variable "gke_namespace" {
+  description = "GKE Namespace"
+  type        = string
+  default     = "fulcio-system"
 }
 
 variable "ctlog_url" {
@@ -63,4 +77,10 @@ variable "ca_pool_name" {
   description = "Certificate authority pool name"
   type        = string
   default     = "sigstore"
+}
+
+variable "create_slos" {
+  description = "True to enable SLO creation"
+  type        = bool
+  default     = false
 }

--- a/terraform/gcp/modules/monitoring/rekor/slo.tf
+++ b/terraform/gcp/modules/monitoring/rekor/slo.tf
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "slos" {
+  source = "../slo"
+  count  = var.create_slos ? 1 : 0
+
+  project_id    = var.project_id
+  service_id    = "rekor"
+  display_name  = "Rekor"
+  resource_name = format("//container.googleapis.com/projects/%s/locations/%s/clusters/%s/k8s/namespaces/%s", var.project_id, var.cluster_location, var.cluster_name, var.gke_namespace)
+
+
+  availability_slos = {
+    server-availability = {
+      display_prefix            = "Availability (Server)"
+      base_total_service_filter = "metric.type=\"prometheus.googleapis.com/rekor_qps_by_api/counter\" resource.type=\"prometheus_target\""
+      # Only count 500s as server errors since clients can trigger 400s.
+      bad_filter = "metric.labels.code=monitoring.regex.full_match(\"5[0-9][0-9]\")"
+      slos = {
+        api-v1-all-methods = {
+          display_suffix = "All Methods"
+          label_filter   = "metric.labels.path!=\"/api/v1/index/retrieve\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-get = {
+          display_suffix = "/api/v1/log - GET"
+          label_filter   = "metric.labels.path=\"/api/v1/log\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-get = {
+          display_suffix = "/api/v1/log/entries - GET"
+          label_filter   = "metric.labels.path=\"/api/v1/log/entries\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-post = {
+          display_suffix = "/api/v1/log/entries - POST"
+          label_filter   = "metric.labels.path=\"/api/v1/log/entries\" metric.labels.method=\"POST\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-uuid-get = {
+          display_suffix = "/api/v1/log/entries/{entryUUID} - GET"
+          label_filter   = "metric.labels.path=\"/api/v1/log/entries/{entryUUID}\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-proof-get = {
+          display_suffix = "/api/v1/log/proof - GET"
+          label_filter   = "metric.labels.path=\"/api/v1/log/proof\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-retrieve-post = {
+          display_suffix = "/api/v1/log/entries/retrieve - POST"
+          label_filter   = "metric.labels.path=\"/api/v1/log/entries/retrieve\" metric.labels.method=\"POST\""
+          goal           = 0.995
+        },
+        api-v1-index-retrieve-post = {
+          display_suffix = "/api/v1/index/retrieve - POST"
+          label_filter   = "metric.labels.path=\"/api/v1/index/retrieve\" metric.labels.method=\"POST\""
+          goal           = 0.8
+        },
+      }
+    },
+    prober-availability = {
+      display_prefix            = "Availability (Prober)"
+      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/api_endpoint_latency_count/summary\" resource.type=\"prometheus_target\" metric.labels.host=\"%s\"", var.prober_url)
+      bad_filter                = "metric.labels.status_code!=monitoring.regex.full_match(\"20[0-1]\")"
+      slos = {
+        api-v1-all-methods = {
+          display_suffix = "All Methods"
+          # exclude unsupported APIs in total availability SLO - data still exists for "version" API
+          label_filter = "metric.labels.endpoint!=\"/api/v1/version\" metric.labels.endpoint!=\"/api/v1/index/retrieve\" metric.labels.method=\"GET\""
+          goal         = 0.995
+        },
+        api-v1-index-retrieve-post = {
+          display_suffix = "/api/v1/index/retrieve - POST"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/index/retrieve\" metric.labels.method=\"POST\""
+          goal           = 0.8
+        },
+        api-v1-log-get = {
+          display_suffix = "/api/v1/log - GET"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-get = {
+          display_suffix = "/api/v1/log/entries - GET"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log/entries\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-post = {
+          display_suffix = "/api/v1/log/entries - POST"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log/entries\" metric.labels.method=\"POST\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-uuid-get = {
+          display_suffix = "/api/v1/log/entries/{entryUUID} - GET"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log/entries/{entryUUID}\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-entries-retrieve-post = {
+          display_suffix = "/api/v1/log/entries/retrieve - POST"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log/entries/retrieve\" metric.labels.method=\"POST\""
+          goal           = 0.995
+        },
+        api-v1-log-proof-get = {
+          display_suffix = "/api/v1/log/proof - GET"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log/proof\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+        api-v1-log-publickey-get = {
+          display_suffix = "/api/v1/log/publicKey - GET"
+          label_filter   = "metric.labels.endpoint=\"/api/v1/log/publicKey\" metric.labels.method=\"GET\""
+          goal           = 0.995
+        },
+      }
+    }
+  }
+}

--- a/terraform/gcp/modules/monitoring/rekor/variables.tf
+++ b/terraform/gcp/modules/monitoring/rekor/variables.tf
@@ -23,10 +23,37 @@ variable "project_id" {
   }
 }
 
+variable "cluster_location" {
+  description = "Zone or Region to create cluster in."
+  type        = string
+  default     = "us-central1"
+}
+
+// Optional values that can be overridden or appended to if desired.
+variable "cluster_name" {
+  description = "The name of the Kubernetes cluster."
+  type        = string
+  default     = ""
+}
+
 // URLs for Sigstore services
 variable "rekor_url" {
   description = "Rekor URL"
   default     = "rekor.sigstore.dev"
+}
+
+// URLs for Sigstore services
+variable "prober_url" {
+  description = "Rekor Prober URL"
+  type        = string
+  default     = ""
+}
+
+// Namespace for monitored service
+variable "gke_namespace" {
+  description = "GKE Namespace"
+  type        = string
+  default     = "rekor-system"
 }
 
 // Set-up for notification channel for alerting
@@ -48,3 +75,8 @@ locals {
   notification_channels = toset([for nc in var.notification_channel_ids : format("projects/%v/notificationChannels/%v", var.project_id, nc)])
 }
 
+variable "create_slos" {
+  description = "True to enable SLO creation"
+  type        = bool
+  default     = false
+}

--- a/terraform/gcp/modules/monitoring/sigstore.tf
+++ b/terraform/gcp/modules/monitoring/sigstore.tf
@@ -37,6 +37,10 @@ module "rekor" {
   project_id               = var.project_id
   notification_channel_ids = var.notification_channel_ids
   rekor_url                = var.rekor_url
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  prober_url               = var.prober_rekor_url
+  create_slos              = var.create_slos
 
   depends_on = [
     google_project_service.service
@@ -51,6 +55,10 @@ module "fulcio" {
   notification_channel_ids = var.notification_channel_ids
   ctlog_url                = var.ctlog_url
   fulcio_url               = var.fulcio_url
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  prober_url               = var.prober_fulcio_url
+  create_slos              = var.create_slos
 
   depends_on = [
     google_project_service.service

--- a/terraform/gcp/modules/monitoring/slo/main.tf
+++ b/terraform/gcp/modules/monitoring/slo/main.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_custom_service" "service" {
+  project      = var.project_id
+  service_id   = var.service_id
+  display_name = var.display_name
+
+  dynamic "telemetry" {
+    for_each = length(var.resource_name) > 0 ? ["yes"] : []
+    content {
+      resource_name = var.resource_name
+    }
+  }
+}
+
+locals {
+  flattened_availability_slos = flatten([
+    for category_id, availability_slo_category in var.availability_slos : [
+      for slo_id, slo in availability_slo_category.slos : {
+        slo_id               = "${category_id}-${slo_id}"
+        display_name         = "${format("%.1f%%", slo.goal * 100)} ${availability_slo_category.display_prefix} : ${slo.display_suffix}"
+        goal                 = slo.goal
+        bad_service_filter   = "${availability_slo_category.base_total_service_filter} ${availability_slo_category.bad_filter} ${slo.label_filter}"
+        total_service_filter = "${availability_slo_category.base_total_service_filter} ${slo.label_filter}"
+      }
+    ]
+  ])
+}
+
+resource "google_monitoring_slo" "availability_slo" {
+  for_each = {
+    for flattened_slo in local.flattened_availability_slos :
+    "${flattened_slo.slo_id}" => flattened_slo
+  }
+  project = var.project_id
+  service = google_monitoring_custom_service.service.service_id
+
+  slo_id              = each.key
+  goal                = each.value.goal
+  rolling_period_days = 30
+  display_name        = each.value.display_name
+
+  request_based_sli {
+    good_total_ratio {
+      bad_service_filter   = each.value.bad_service_filter
+      total_service_filter = each.value.total_service_filter
+    }
+  }
+}

--- a/terraform/gcp/modules/monitoring/slo/variables.tf
+++ b/terraform/gcp/modules/monitoring/slo/variables.tf
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project ID in which the monitored service lives."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "Must specify PROJECT_ID variable."
+  }
+}
+
+variable "service_id" {
+  description = "Resource ID for the monitoring service."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.service_id) > 0
+    error_message = "Must specify serivce_id variable."
+  }
+}
+
+variable "display_name" {
+  description = "Friendly name for the monitored service."
+  type        = string
+  default     = ""
+}
+
+variable "resource_name" {
+  description = "Resource name (e.g. k8s namespace) for telemetry and logs of the service."
+  type        = string
+  default     = ""
+}
+
+/* availability_slos define 30-day window, request based availability SLOs, grouped by category.
+ *
+ * Example usage:
+ *
+ * availability_slos = {
+ *   server-slo {
+ *     display_prefix            = "Server Availability"
+ *     base_total_service_filter = "metric.type=\"<metric_uri>\" resource.type=\"prometheus_target\""
+ *     bad_filter                = "metrics.labels.status!=\"OK\""
+ *     slos {
+ *       rpc1 {
+ *         goal           = 0.995
+ *         display_suffix = "RPC1"
+ *         label_filter   = "metrics.labels.rpc = \"RPC1\""
+ *
+ *       },
+ *       rpc2 {
+ *         ...
+ *       },
+ *       ...
+ *     },
+ *   },
+ *   prober-slo = {
+ *     ...
+ *     slos {
+ *       rpc1 {
+ *         ...
+ *       }
+ *     ...
+ *   },
+ * }
+ *
+ *
+ * Defines SLOs with:
+ *
+ * 1.
+ * slo_id               = "server-slo-rpc1"
+ * display_name         = "99.5% Server Availability RPC1"
+ * total_service_filter = "metric.type=\"<metric_uri>\" resource.type=\"prometheus_target\" metrics.labels.rpc = \"RPC1\""
+ * bad_service_filter   = "metric.type=\"<metric_uri>\" resource.type=\"prometheus_target\" metrics.labels.rpc = \"RPC1\" metrics.labels.status!=\"OK\""
+ * goal                 = 0.995
+ *
+ * 2.
+ * slo_id               = "server-slo-rpc2"
+ * ...
+ *
+ * n.
+ * slo_id               = "prober-slo-rpc1"
+ * ...
+ *
+ * Note: map keys are concatenated together with a hyphen to create the SLO id. SLO
+ * ids must match "^[a-z0-9\\-]+$" or they will be rejected at create time.
+ */
+variable "availability_slos" {
+  type = map(object(
+    {
+      display_prefix            = string,
+      base_total_service_filter = string,
+      bad_filter                = string,
+      slos = map(object({
+        goal           = number,
+        display_suffix = string,
+        label_filter   = string,
+      }))
+  }))
+  default = {}
+}

--- a/terraform/gcp/modules/monitoring/slo/versions.tf
+++ b/terraform/gcp/modules/monitoring/slo/versions.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.1.3, < 1.4.0"
+
+  required_providers {
+    google = {
+      version = ">= 4.11.0, < 4.38.0"
+      source  = "hashicorp/google"
+    }
+    google-beta = {
+      version = ">= 4.11.0, < 4.38.0"
+      source  = "hashicorp/google-beta"
+    }
+    random = {
+      version = ">= 3.1.0, < 3.2.0"
+      source  = "hashicorp/random"
+    }
+  }
+}

--- a/terraform/gcp/modules/monitoring/variables.tf
+++ b/terraform/gcp/modules/monitoring/variables.tf
@@ -86,3 +86,9 @@ variable "ca_pool_name" {
   type        = string
   default     = "sigstore"
 }
+
+variable "create_slos" {
+  description = "Creates SLOs when true."
+  type        = bool
+  default     = false
+}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -62,13 +62,14 @@ module "monitoring" {
   count = var.monitoring.enabled ? 1 : 0
 
   project_id               = var.project_id
-  cluster_location         = var.project_id
+  cluster_location         = module.gke-cluster.cluster_location
   cluster_name             = var.cluster_name
   ca_pool_name             = var.ca_pool_name
   fulcio_url               = var.monitoring.fulcio_url
   rekor_url                = var.monitoring.rekor_url
   dex_url                  = var.monitoring.dex_url
   notification_channel_ids = var.monitoring.notification_channel_ids
+  create_slos              = var.create_slos
 
   depends_on = [
     module.gke-cluster

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -102,6 +102,12 @@ variable "monitoring" {
   }
 }
 
+variable "create_slos" {
+  description = "Creates SLOs when true. (Monitoring must be enabled.)"
+  type        = bool
+  default     = false
+}
+
 // Optional values that can be overridden or appended to if desired.
 variable "cluster_name" {
   description = "The name to give the new Kubernetes cluster."


### PR DESCRIPTION
When enabled, this terraform creates custom monitoring services for Fulcio and Rekor and adds availability SLOs by server and prober metrics. We target 99.5% availability for supported methods and 80% availability for unsupported (redis index.) Alerts will be wired up in later changes.

SLO creation is off by default and must be enabled by setting the "create_slos" variable to true in the root sigstore module.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->