### PR TITLE
Update k8s log alert policy filters

### DIFF
--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -195,7 +195,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_contai
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
-      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/restarting-failed-container\""
+      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/restarting-failed-container\" resource.type=\"metric\""
       threshold_value         = "1"
 
       trigger {
@@ -238,7 +238,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_unschedulable" {
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
-      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/unschedulable\""
+      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/unschedulable\" resource.type=\"metric\""
       threshold_value         = "1"
 
       trigger {

--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -195,7 +195,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_contai
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
-      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/restarting-failed-container\" resource.type=\"metric\""
+      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\""
       threshold_value         = "1"
 
       trigger {
@@ -238,7 +238,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_unschedulable" {
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
-      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/unschedulable\" resource.type=\"metric\""
+      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/unschedulable\" resource.type=\"k8s_pod\""
       threshold_value         = "1"
 
       trigger {

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -68,7 +68,7 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_contain
 
   conditions {
     condition_threshold {
-      filter         = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\""
+      filter         = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\" resource.type=\"metric\""
       duration       = "600s"
       comparison     = "COMPARISON_GE"
       hreshold_value = "1"
@@ -115,7 +115,7 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_unschedulable" {
 
       comparison      = "COMPARISON_GT"
       duration        = "600s"
-      filter          = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/unschedulable\""
+      filter          = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/unschedulable\" resource.type=\"metric\""
       threshold_value = "1"
 
       trigger {

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -75,7 +75,7 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_contain
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
-      filter                  = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\" resource.type=\"metric\""
+      filter                  = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\""
       threshold_value         = "1"
 
       trigger {
@@ -117,7 +117,7 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_unschedulable" {
 
       comparison      = "COMPARISON_GT"
       duration        = "600s"
-      filter          = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/unschedulable\" resource.type=\"metric\""
+      filter          = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/unschedulable\" resource.type=\"k8s_pod\""
       threshold_value = "1"
 
       trigger {

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -59,7 +59,6 @@ resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
 
 resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_container" {
   # In the absence of data, incident will auto-close in 7 days
-
   alert_strategy {
     auto_close = "604800s"
   }
@@ -68,27 +67,30 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_contain
 
   conditions {
     condition_threshold {
-      filter         = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\" resource.type=\"metric\""
-      duration       = "600s"
-      comparison     = "COMPARISON_GE"
-      hreshold_value = "1"
+      aggregations {
+        alignment_period   = "600s"
+        per_series_aligner = "ALIGN_COUNT"
+      }
+
+      comparison              = "COMPARISON_GT"
+      duration                = "600s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
+      filter                  = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\" resource.type=\"metric\""
+      threshold_value         = "1"
+
       trigger {
         count   = "1"
         percent = "0"
       }
-      aggregations {
-        alignment_period   = "60s"
-        per_series_aligner = "ALIGN_RATE"
-      }
     }
 
-    display_name = "K8s Restart Failing Container for at least ten minutes"
+    display_name = "K8s Restart Failing Container for more than ten minutes"
   }
 
   display_name = "Rekor K8s Restart Failing Container"
 
   documentation {
-    content   = "K8s is restarting a failing container for longer than the accepted time limit, please see playbook for help."
+    content   = "K8s is restarting a failing container for longer than the accepted time limit, please see playbook for help.\n"
     mime_type = "text/markdown"
   }
 

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -68,9 +68,14 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_contain
 
   conditions {
     condition_threshold {
-      filter     = "metric.name=\"rekor/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\""
-      duration   = "600s"
-      comparison = "COMPARISON_GE"
+      filter         = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\""
+      duration       = "600s"
+      comparison     = "COMPARISON_GE"
+      hreshold_value = "1"
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
       aggregations {
         alignment_period   = "60s"
         per_series_aligner = "ALIGN_RATE"
@@ -110,7 +115,7 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_unschedulable" {
 
       comparison      = "COMPARISON_GT"
       duration        = "600s"
-      filter          = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/restarting-failed-container\""
+      filter          = "metric.type=\"logging.googleapis.com/user/rekor/k8s_pod/unschedulable\""
       threshold_value = "1"
 
       trigger {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The original filters were created in the GCP UI and then ported to Terraform using the terraformer tool. The UI did not indicate any issues with the filter. However [this line](https://github.com/sigstore/public-good-instance/actions/runs/3178209563/jobs/5179470236#step:11:160) of a failing provision staging environment job shows that whatever API Terraform is using to create the policy requires a `resource.type` in the filter.

I add `resource.type=k8s_pod` to the filters since the metrics in question only monitor logs from sources that match the filter `resource.type=k8s_pod`. The monitored k8s_pod resource type can be read about [here](https://cloud.google.com/monitoring/api/resources#tag_k8s_pod).

I confirm this addition to the policy filter works in the UI with one of the original test policies I created in the UI: https://console.cloud.google.com/monitoring/alerting/policies/17630789102851815676?project=projectsigstore-staging . The test alerts and metrics I created will be deleted after Terraform based metrics and alert policies have been created successfully.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->