### PR TITLE
Create alert for prober verification failures

### DIFF
--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -184,3 +184,37 @@ resource "google_monitoring_alert_policy" "prober_error_codes" {
   notification_channels = local.notification_channels
   project               = var.project_id
 }
+
+resource "google_monitoring_alert_policy" "prober_verification" {
+  alert_strategy {
+    auto_close = "604800s"
+  }
+
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "0s"
+      filter          = "resource.type = \"k8s_container\" AND metric.type = \"external.googleapis.com/prometheus/verification\" AND metric.labels.verified = \"false\""
+      threshold_value = "0"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Kubernetes Container - external/prometheus/verification"
+  }
+
+  display_name          = "API Prober: Verification failed at least once in the last 60s"
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+}

--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -213,7 +213,12 @@ resource "google_monitoring_alert_policy" "prober_verification" {
     display_name = "Kubernetes Container - external/prometheus/verification"
   }
 
-  display_name          = "API Prober: Verification failed at least once in the last 60s"
+  documentation {
+    content   = "An entry written to Rekor produced an unverifiable response at least once in the last 60s.\n"
+    mime_type = "text/markdown"
+  }
+
+  display_name          = "API Prober: Rekor write correctness verifier returned 'false' within the last 60s"
   enabled               = "true"
   notification_channels = local.notification_channels
   project               = var.project_id


### PR DESCRIPTION
Any single prober verification failure should yield an alert, as described in the ticket.

Related ticket: https://github.com/sigstore/scaffolding/issues/351
public-good-instance ticket: https://github.com/sigstore/public-good-instance/issues/711
Prober feature: https://github.com/sigstore/scaffolding/pull/390

Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->