### PR TITLE
add explicit dependencies on the associated metrics

### DIFF
--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -178,6 +178,10 @@ resource "google_monitoring_alert_policy" "ca_service_cert_quota" {
 ### K8s Alerts
 
 resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_container" {
+  # adding a dependency on the associated metric means that Terraform will 
+  # always try to   apply changes to the metric before this alert
+  depends_on = [google_logging_metric.fulcio_k8s_pod_restart_failing_container]
+
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
@@ -220,6 +224,10 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_contai
 }
 
 resource "google_monitoring_alert_policy" "fulcio_k8s_pod_unschedulable" {
+  # adding a dependency on the associated metric means that Terraform will 
+  # always try to   apply changes to the metric before this alert
+  depends_on = [google_logging_metric.k8s_pod_unschedulable]
+
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"

--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -179,7 +179,7 @@ resource "google_monitoring_alert_policy" "ca_service_cert_quota" {
 
 resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_container" {
   # adding a dependency on the associated metric means that Terraform will 
-  # always try to   apply changes to the metric before this alert
+  # always try to apply changes to the metric before this alert
   depends_on = [google_logging_metric.fulcio_k8s_pod_restart_failing_container]
 
   # In the absence of data, incident will auto-close in 7 days
@@ -225,7 +225,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_contai
 
 resource "google_monitoring_alert_policy" "fulcio_k8s_pod_unschedulable" {
   # adding a dependency on the associated metric means that Terraform will 
-  # always try to   apply changes to the metric before this alert
+  # always try to apply changes to the metric before this alert
   depends_on = [google_logging_metric.k8s_pod_unschedulable]
 
   # In the absence of data, incident will auto-close in 7 days

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -59,7 +59,7 @@ resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
 
 resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_container" {
   # adding a dependency on the associated metric means that Terraform will 
-  # always try to   apply changes to the metric before this alert
+  # always try to apply changes to the metric before this alert
   depends_on = [google_logging_metric.rekor_k8s_pod_restart_failing_container]
 
   # In the absence of data, incident will auto-close in 7 days
@@ -105,7 +105,7 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_contain
 
 resource "google_monitoring_alert_policy" "rekor_k8s_pod_unschedulable" {
   # adding a dependency on the associated metric means that Terraform will 
-  # always try to   apply changes to the metric before this alert
+  # always try to apply changes to the metric before this alert
   depends_on = [google_logging_metric.k8s_pod_unschedulable]
 
   # In the absence of data, incident will auto-close in 7 days

--- a/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
+++ b/terraform/gcp/modules/monitoring/rekor/rekor_alerts.tf
@@ -58,6 +58,10 @@ resource "google_monitoring_alert_policy" "rekor_uptime_alerts" {
 ### K8s Alerts
 
 resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_container" {
+  # adding a dependency on the associated metric means that Terraform will 
+  # always try to   apply changes to the metric before this alert
+  depends_on = [google_logging_metric.rekor_k8s_pod_restart_failing_container]
+
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
@@ -100,8 +104,11 @@ resource "google_monitoring_alert_policy" "rekor_k8s_pod_restart_failing_contain
 }
 
 resource "google_monitoring_alert_policy" "rekor_k8s_pod_unschedulable" {
-  # In the absence of data, incident will auto-close in 7 days
+  # adding a dependency on the associated metric means that Terraform will 
+  # always try to   apply changes to the metric before this alert
+  depends_on = [google_logging_metric.k8s_pod_unschedulable]
 
+  # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
   }


### PR DESCRIPTION
Signed-off-by: Meredith Lancaster <malancas@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes https://github.com/sigstore/public-good-instance/issues/867.

This PR adds explicit dependencies to the new k8s error alert policies. These are dependent on the k8 error log based metrics that the policies monitor. This means that Terraform should always try to apply changes to the metrics first before the alert policies. This should prevent `terraform apply` errors caused by Terraform attempting to apply changes to the policies first.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

None.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

None.