### PR TITLE
increase redis memory to prevent OOM errors in Rekor prod

### DIFF
--- a/terraform/gcp/modules/redis/main.tf
+++ b/terraform/gcp/modules/redis/main.tf
@@ -66,7 +66,7 @@ resource "google_redis_instance" "index" {
   display_name   = "Rekor Index Instance"
   name           = "rekor-index"
   tier           = "STANDARD_HA"
-  memory_size_gb = 3 // Usage as of 2022/03/16 is 120 MiB
+  memory_size_gb = 15 // Usage as of 2022/11/03 is 3 GiB
   redis_version  = "REDIS_6_X"
 
   region                  = var.region // Used for naming, location determined by location_id


### PR DESCRIPTION
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>


#### Summary

Fix production errors in rekor when calling redis due to redis OOM

#### Release Note
n/a

#### Documentation
n/a