### PR TITLE
Change to publish instead of save because action does not start.

### DIFF
--- a/release.md
+++ b/release.md
@@ -13,7 +13,7 @@ You should be part of the `scaffolding-codeowners` or `sigstore-oncall` groups, 
 1. Click on the `+ Create new tag: v0.4.11 on publish` button that appears.
 1. For the release title, use the tag name: v0.4.11,
 1. Click the `Generate release notes` button
-1. Click the `Save Draft` button to trigger the `Release` action.
+1. Verify everything looks good and then clieck `Publish` button to trigger the `Release` action.
 1. Monitor the [`Release` action](https://github.com/sigstore/scaffolding/actions/workflows/release.yaml), which generates the remaining release artifacts
 1. Once the `Release` action has been completed successfully, find your draft release at the [releases page](https://github.com/sigstore/scaffolding/releases)
 1. Click the green "Publish release" button


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The release action did not kick off after hitting save alone. It required hitting the `Publish`.

@cpanato or did I miss some step somewhere?

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->