### PR TITLE
release docs: readability improvements

### DIFF
--- a/release.md
+++ b/release.md
@@ -7,51 +7,65 @@ You should be part of the `scaffolding-codeowners` or `sigstore-oncall` groups, 
 
 ## Steps
 
-### Make sure your local branch is up-to-date from the upstream, for example:
+### Sync tags
+
+Ensure that sure your local branch is up-to-date from the upstream:
 
 ```shell
 git pull upstream main --tags
 ```
 
-### Verify the correct version you're about to tag:
+### Pick a new version number
+
+The scaffolding repo uses [semver](https://semver.org/). Your first step is to determine the latest tag used.
+
+List the latest tags in date order:
 
 ```shell
-git tag
+git tag | tail
 ```
 
-This will list all the tags, so the latest (at the time of this writing), was:
-`v0.5.1`
+Example output:
+
+```
+...
+v0.0.0
+v0.1.0
+```
+
+Show a list of changes since the latest version (v0.1.0):
 
 ```shell
-vaikas@villes-mbp scaffolding % git tag
-v0.1-alpha
-v0.1.1-alpha
-v0.1.10-alpha
-v0.1.11-alpha
-<SNIPPED FOR READABILITY>
-v0.4.9
-v0.5.0
-v0.5.1
+git log v0.1.0..
 ```
 
-So, I will release `v0.5.2`
+If the commits include a new feature or breaking change, bump the minor version. If it only includes bug fixes, bump the patch version.
 
-### Tag the release with the new version number, for instance `v0.5.2`
+### Tagging
+
+Once you have a version number in mind, tag it locally:
 
 ```shell
-git tag -a v0.5.2 -m "v0.5.2"
+git tag -a v0.2.0 -m v0.2.0
 ```
 
-### Push the tag
+Then push the tag upstream:
 
 ```shell
-git push upstream v0.5.2
+git push upstream v0.2.0
 ```
 
-### Monitor the [`Release` action](https://github.com/sigstore/scaffolding/actions/workflows/release.yaml), which generates the remaining release artifacts
+### Monitor the release automation
 
-### Once the `Release` action has been completed successfully, find your draft release at the [releases page](https://github.com/sigstore/scaffolding/releases)
+Once the tag is pushed, the [`Release` action](https://github.com/sigstore/scaffolding/actions/workflows/release.yaml) will generate the appropriate release artifacts and create a draft release.
 
-### Update the release notes by clicking on the `Generate release notes` button
+Be sure to see how long recent runs have taken. At the time of this writing, the release job takes 30 to 40 minutes to execute.
 
-### Click the green "Publish release" button
+### Publish
+
+Once the `Release` action has been completed successfully:
+
+1. Find your draft release on the [releases page](https://github.com/sigstore/scaffolding/releases)
+2. Click the `Generate release notes` button to fill in the "What's Changed" section
+3. Click the green `Publish release` button
+4. 🎉


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Minor readability updates to the scaffolding release docs, based on following the instructions today for the v0.5.4 release.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->