### PR TITLE
add argocd-apps

### DIFF
--- a/terraform/gcp/modules/argocd/argocd.tf
+++ b/terraform/gcp/modules/argocd/argocd.tf
@@ -92,7 +92,7 @@ resource "helm_release" "argocd" {
   ]
 }
 
-resource "helm_release" "argocd_apss" {
+resource "helm_release" "argocd_apps" {
   name       = "argocd-apps"
   namespace  = "argocd"
   chart      = "argocd-apps"

--- a/terraform/gcp/modules/argocd/argocd.tf
+++ b/terraform/gcp/modules/argocd/argocd.tf
@@ -91,3 +91,20 @@ resource "helm_release" "argocd" {
     kubectl_manifest.externalsecret_argocd_slack
   ]
 }
+
+resource "helm_release" "argocd_apss" {
+  name       = "argocd-apps"
+  namespace  = "argocd"
+  chart      = "argocd-apps"
+  repository = "https://argoproj.github.io/argo-helm"
+  version    = var.argocd_apps_chart_version
+  timeout    = 900
+
+  values = [
+    file(var.argo_apps_chart_values_yaml_path)
+  ]
+
+  depends_on = [
+    helm_release.argocd
+  ]
+}

--- a/terraform/gcp/modules/argocd/variables.tf
+++ b/terraform/gcp/modules/argocd/variables.tf
@@ -19,8 +19,18 @@ variable "argocd_chart_version" {
   type        = string
 }
 
+variable "argocd_apps_chart_version" {
+  description = "Version of ArgoCD-Apps Helm chart. Versions listed here https://artifacthub.io/packages/helm/argo/argocd-apps"
+  type        = string
+}
+
 variable "argo_chart_values_yaml_path" {
   description = "Path to ArgoCD Helm chart value yaml."
+  type        = string
+}
+
+variable "argo_apps_chart_values_yaml_path" {
+  description = "Path to ArgoCD-Apps Helm chart value yaml."
   type        = string
 }
 


### PR DESCRIPTION
#### Summary
We use `server.additionalApplications` and `server.additionalProjects` from the argocd helm chart but that was deprecated in the release >5.x in favor of the argocd-apps chart.

This PR introduce the argocd-apps