### PR TITLE
add module standalone_sqls for creating one off databases.

### DIFF
--- a/terraform/gcp/modules/sigstore/outputs.tf
+++ b/terraform/gcp/modules/sigstore/outputs.tf
@@ -43,6 +43,18 @@ output "ctlog_mysql_connections" {
   value       = [for ctlog_shard in module.ctlog_shards : ctlog_shard.mysql_connection]
 }
 
+// Outputs a list of strings for each Standalone Cloud SQL instance.
+output "standalone_mysql_instances" {
+  description = "Names of the DB instances created for the standalone MySQLs"
+  value       = [for standalone in module.standalone_mysqls : standalone.mysql_instance]
+}
+
+// Outputs a list of connection strings for each Standalone Cloud SQL instance.
+output "standalone_mysql_connections" {
+  description = "Connection strings of the DB instances created for the standalone MySQLs"
+  value       = [for standalone in module.standalone_mysqls : standalone.mysql_connection]
+}
+
 // Full connection string for the MySQL DB>
 output "mysql_connection" {
   description = "The connection string dynamically generated for storage inside the Kubernetes configmap"

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -284,6 +284,17 @@ variable "ctlog_shards" {
   default     = []
 }
 
+variable "standalone_mysqls" {
+  type        = list(string)
+  description = "Array of Standalone mysql instances to create. Entry should be something like [postfix-1, postfix-2], which would then have 2 independent mysql instances created like <projectid>-<environment>-postfix-1 and  <projectid>-<environment>-postfix-2 Cloud SQL instances. For example running in staging with [rekor-ctlog-2022] would create sigstore-staging-standalone-rekor-ctlog-2022"
+  default     = []
+}
+
+variable "standalone_mysql_tier" {
+  type        = string
+  description = "Machine tier for Standalone MySQL instance."
+  default     = "db-n1-standard-4"
+}
 
 //  Cluster node pool
 variable "initial_node_count" {


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
We need to create a standalone database so that we can migrate off of sql 8.0 to 5.7. So, in case we need to do this again, for whatever reason, created an array that behaves very similary to ctlog shard database instance creation.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Add module standalone_mysqls that allows for creating one off databases with `standalone` in the name.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->