### PR TITLE
Allow user of the action to explicitly specify INSTALL_TSA

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: 'kubernetes version to install (v1.23.x, v1.24.x, v1.25.x), default: v1.24.x'
     required: true
     default: 'v1.24.x'
+  install-tsa:
+    description: 'If not set, will auto-detect whether to install TSA, or "true" or "false" to explictly force install or not of TSA.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -75,6 +79,14 @@ runs:
       INSTALL_TSA="false"
       if [ ${MINOR} -ge 5 ]; then
         INSTALL_TSA="true"
+      fi
+      if [ ${{ inputs.install-tsa }} != "" ]; then
+        echo "overriding INSTALL_TSA with input ${{ inputs.install-tsa }}"
+        INSTALL_TSA=${{ inputs.install-tsa }}
+        if [ ${MINOR} -lt 5 ]; then
+          echo "unable to install TSA on version < 0.5.0"
+          exit 1
+        fi
       fi
       # Anything older than 0.4.0 is not supported.
       if [ ${MINOR} -lt 4 ]; then

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -76,16 +76,10 @@ runs:
       # greater than v0.5.0 and install it.
       # the install process, so check to see if we are running >=5
       MINOR=$(echo $tag | cut -d '.' -f 2)
-      INSTALL_TSA="false"
-      if [ ${MINOR} -ge 5 ]; then
-        INSTALL_TSA="true"
-      fi
-      if [ ${{ inputs.install-tsa }} != "" ]; then
-        echo "overriding INSTALL_TSA with input ${{ inputs.install-tsa }}"
-        INSTALL_TSA=${{ inputs.install-tsa }}
-        if [ ${MINOR} -lt 5 ]; then
-          echo "unable to install TSA on version < 0.5.0"
-          exit 1
+      if [[ -z "${DEPLOY_ENV}" ]]; then
+        INSTALL_TSA="false"
+        if [ ${MINOR} -ge 5 ]; then
+          INSTALL_TSA="true"
         fi
       fi
       # Anything older than 0.4.0 is not supported.

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -72,7 +72,7 @@ runs:
       # greater than v0.5.0 and install it.
       # the install process, so check to see if we are running >=5
       MINOR=$(echo $tag | cut -d '.' -f 2)
-      if [[ -z "${DEPLOY_ENV}" ]]; then
+      if [[ -z "${INSTALL_TSA}" ]]; then
         INSTALL_TSA="false"
         if [ ${MINOR} -ge 5 ]; then
           INSTALL_TSA="true"

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -50,10 +50,6 @@ inputs:
     description: 'kubernetes version to install (v1.23.x, v1.24.x, v1.25.x), default: v1.24.x'
     required: true
     default: 'v1.24.x'
-  install-tsa:
-    description: 'If not set, will auto-detect whether to install TSA, or "true" or "false" to explictly force install or not of TSA.'
-    required: false
-    default: ''
 runs:
   using: "composite"
   steps:

--- a/hack/setup-scaffolding-from-release.sh
+++ b/hack/setup-scaffolding-from-release.sh
@@ -53,7 +53,7 @@ if [ "${MINOR}" -lt 4 ]; then
 fi
 
 # We introduced TSA in release v0.5.0
-if [[ -z "${DEPLOY_ENV}" ]]; then
+if [[ -z "${INSTALL_TSA}" ]]; then
   INSTALL_TSA="false"
   if [ "${MINOR}" -ge 5 ]; then
     INSTALL_TSA="true"

--- a/hack/setup-scaffolding-from-release.sh
+++ b/hack/setup-scaffolding-from-release.sh
@@ -53,9 +53,11 @@ if [ "${MINOR}" -lt 4 ]; then
 fi
 
 # We introduced TSA in release v0.5.0
-INSTALL_TSA="false"
-if [ "${MINOR}" -ge 5 ]; then
-  INSTALL_TSA="true"
+if [[ -z "${DEPLOY_ENV}" ]]; then
+  INSTALL_TSA="false"
+  if [ "${MINOR}" -ge 5 ]; then
+    INSTALL_TSA="true"
+  fi
 fi
 
 # Since the behaviour on oidc is different on k8s <1.23, check to see if we


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Allow users of the scaffolding setup action to explicitly specify INSTALL_TSA to allow disabling the installation of TSA with v0.5.0+

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->