### PR TITLE
adding cloudsqlproxy wrapper and use exitdir to signal when the pod should terminate

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,7 @@
 ---
 defaultBaseImage: cgr.dev/chainguard/alpine-base:latest
+baseImageOverrides:
+  github.com/sigstore/scaffolding/cmd/cloudsqlproxy: gcr.io/cloudsql-docker/gce-proxy:1.32.0-alpine
 
 builds:
   - id: ctlog-createctconfig
@@ -137,6 +139,20 @@ builds:
       - -extldflags "-static"
       - "{{ .Env.LDFLAGS }}"
 
+  - id: cloudsqlproxy
+    dir: .
+    main: ./cmd/cloudsqlproxy
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
   - id: getoidctoken
     dir: .

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,7 @@
 ---
 defaultBaseImage: cgr.dev/chainguard/alpine-base:latest
 baseImageOverrides:
-  github.com/sigstore/scaffolding/cmd/cloudsqlproxy: gcr.io/cloudsql-docker/gce-proxy:1.32.0-alpine
+  github.com/sigstore/scaffolding/cmd/cloudsqlproxy: gcr.io/cloudsql-docker/gce-proxy:1.33.1-alpine
 
 builds:
   - id: ctlog-createctconfig

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,182 +1,184 @@
+---
 defaultBaseImage: cgr.dev/chainguard/alpine-base:latest
 
 builds:
-- id: ctlog-createctconfig
-  dir: .
-  main: ./cmd/ctlog/createctconfig
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: ctlog-createctconfig
+    dir: .
+    main: ./cmd/ctlog/createctconfig
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: ctlog-managectroots
-  dir: .
-  main: ./cmd/ctlog/managectroots
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: ctlog-managectroots
+    dir: .
+    main: ./cmd/ctlog/managectroots
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: ctlog-verifyfulcio
-  dir: .
-  main: ./cmd/ctlog/verifyfulcio
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: ctlog-verifyfulcio
+    dir: .
+    main: ./cmd/ctlog/verifyfulcio
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: fulcio-createcerts
-  dir: .
-  main: ./cmd/fulcio/createcerts
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: fulcio-createcerts
+    dir: .
+    main: ./cmd/fulcio/createcerts
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: tuf-createsecret
-  dir: .
-  main: ./cmd/tuf/createsecret
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: tuf-createsecret
+    dir: .
+    main: ./cmd/tuf/createsecret
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: tuf-server
-  dir: .
-  main: ./cmd/tuf/server
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: tuf-server
+    dir: .
+    main: ./cmd/tuf/server
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: trillian-createtree
-  dir: .
-  main: ./cmd/trillian/createtree
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: trillian-createtree
+    dir: .
+    main: ./cmd/trillian/createtree
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: trillian-createdb
-  dir: .
-  main: ./cmd/trillian/createdb
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: trillian-createdb
+    dir: .
+    main: ./cmd/trillian/createdb
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: trillian-updatetree
-  dir: .
-  main: ./cmd/trillian/updatetree
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: trillian-updatetree
+    dir: .
+    main: ./cmd/trillian/updatetree
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: getoidctoken
-  dir: .
-  main: ./cmd/getoidctoken
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
 
-- id: prober
-  dir: .
-  main: ./cmd/prober
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: getoidctoken
+    dir: .
+    main: ./cmd/getoidctoken
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
 
-- id: rekor-createsecret
-  dir: .
-  main: ./cmd/rekor/createsecret
-  env:
-  - CGO_ENABLED=0
-  flags:
-  - -trimpath
-  - -tags
-  - nostackdriver
-  ldflags:
-  - -s
-  - -w
-  - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"
+  - id: prober
+    dir: .
+    main: ./cmd/prober
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"
+
+  - id: rekor-createsecret
+    dir: .
+    main: ./cmd/rekor/createsecret
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -tags
+      - nostackdriver
+    ldflags:
+      - -s
+      - -w
+      - -extldflags "-static"
+      - "{{ .Env.LDFLAGS }}"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ ko-resolve:
 	ko resolve --tags $(GIT_TAG),latest -BRf ./config/$(artifact) \
 	--platform=all \
 	--image-refs imagerefs-$(artifact) > release-$(artifact).yaml )) \
+	# "Building cloudsqlproxy wrapper"
+	LDFLAGS="$(LDFLAGS)" KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
+	ko build --base-import-paths --platform=all --tags $(GIT_TAG),latest --image-refs imagerefs-cloudsqlproxy ./cmd/cloudsqlproxy
 
 .PHONY: ko-resolve-testdata
 ko-resolve-testdata:
@@ -32,6 +35,7 @@ sign-release-images: sign-test-images
 	$(foreach artifact,$(artifacts), \
 		echo "Signing $(artifact)"; export GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_TAG) ARTIFACT=imagerefs-$(artifact); ./scripts/sign-release-images.sh \
 	)
+	echo "Signing cloudsqlproxy"; export GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_TAG) ARTIFACT=imagerefs-cloudsqlproxy; ./scripts/sign-release-images.sh \
 
 .PHONY: release-images
 release-images: ko-resolve ko-resolve-testdata

--- a/cmd/cloudsqlproxy/main.go
+++ b/cmd/cloudsqlproxy/main.go
@@ -30,7 +30,7 @@ func main() {
 	ctx := exitdir.Aware(signals.NewContext())
 
 	log.Printf("Starting the cloud sql proxy")
-	cmd := exec.CommandContext(ctx, "/cloud_sql_proxy", os.Args[1:]...)
+	cmd := exec.CommandContext(ctx, "/cloud_sql_proxy", os.Args[1:]...) //nolint: gosec
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/cloudsqlproxy/main.go
+++ b/cmd/cloudsqlproxy/main.go
@@ -1,0 +1,43 @@
+// Copyright 2023 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+
+	"chainguard.dev/exitdir"
+	"knative.dev/pkg/signals"
+)
+
+// Assuming the base image is image: gcr.io/cloudsql-docker/gce-proxy.
+
+func main() {
+	// Leverage exitdir to use file based lifecycle management.
+	ctx := exitdir.Aware(signals.NewContext())
+
+	log.Printf("Starting the cloud sql proxy")
+	cmd := exec.CommandContext(ctx, "/cloud_sql_proxy", os.Args[1:]...)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Panic(err)
+	}
+
+	<-ctx.Done()
+	log.Println("Exiting")
+}

--- a/cmd/trillian/createdb/main.go
+++ b/cmd/trillian/createdb/main.go
@@ -24,6 +24,8 @@ import (
 
 	"database/sql"
 
+	"chainguard.dev/exitdir"
+
 	_ "github.com/go-sql-driver/mysql"
 
 	"knative.dev/pkg/logging"
@@ -208,6 +210,11 @@ var (
 )
 
 func main() {
+	// Signal via exitdir we are finished.
+	defer func() {
+		_ = exitdir.Exit()
+	}()
+
 	flag.Parse()
 	if *mysqlURI == "" {
 		log.Panicf("Need to specify mysql_uri to know where to connect to")
@@ -215,6 +222,7 @@ func main() {
 	if *dbName == "" {
 		log.Panicf("Need to specify database name")
 	}
+
 	connStr := fmt.Sprintf("%s/%s", strings.TrimSuffix(*mysqlURI, "/"), *dbName)
 	ctx := signals.NewContext()
 	db, err := sql.Open("mysql", connStr)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sigstore/scaffolding
 go 1.19
 
 require (
+	chainguard.dev/exitdir v0.0.1
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.22.3
 	github.com/go-sql-driver/mysql v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+chainguard.dev/exitdir v0.0.1 h1:gYH0OCCE5mbHKNTkTzmeqX2pa8f7txAcTeNLmoOZGGE=
+chainguard.dev/exitdir v0.0.1/go.mod h1:qs/nTdekhJH7TvwwOsY+dyJW8jXVowlaqTsi/i23SbY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=


### PR DESCRIPTION
#### Summary
- adding cloudsqlproxy wrapper and use exitdir to signal when the pod should terminate

in our public instance we use cloudsql and the cloudsql-proxy to connect in the DB
however in the `createdb` job the cloudsql run forever and never finish because it is not aware of the main container that creates the db, using the `https://github.com/chainguard-dev/exitdir` we can signal from `createdb` to cloudproxy when we are ready and then the job the gracefully finish


This is the first part of the fix and the second is to update https://github.com/sigstore/helm-charts/blob/main/charts/trillian/templates/createdb/createdb-job.yaml to use this image


This will fix: https://github.com/sigstore/public-good-instance/issues/965

