### PR TITLE
remove experiment to unblock tf upgrade

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.0
         with:
           # TODO: extract terraform from the tf file when we have pinned
-          terraform_version: 1.3.9
+          terraform_version: 1.1.6
 
       - name: Terraform fmt
         id: fmt
@@ -46,7 +46,7 @@ jobs:
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.0
         with:
           # TODO: extract terraform from the tf file when we have pinned
-          terraform_version: 1.3.9
+          terraform_version: 1.1.6
 
       - name: Terraform init
         id: init

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.0
         with:
           # TODO: extract terraform from the tf file when we have pinned
-          terraform_version: 1.1.6
+          terraform_version: 1.3.9
 
       - name: Terraform fmt
         id: fmt
@@ -46,7 +46,7 @@ jobs:
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.0
         with:
           # TODO: extract terraform from the tf file when we have pinned
-          terraform_version: 1.1.6
+          terraform_version: 1.3.9
 
       - name: Terraform init
         id: init

--- a/terraform/gcp/modules/monitoring/slo/versions.tf
+++ b/terraform/gcp/modules/monitoring/slo/versions.tf
@@ -17,8 +17,6 @@
 terraform {
   required_version = ">= 1.1.3, < 1.4.0"
 
-  experiments = [module_variable_optional_attrs]
-
   required_providers {
     google = {
       version = ">= 4.11.0, < 4.38.0"


### PR DESCRIPTION
This allows for more recent versions of terraform to be used.