### PR TITLE
swaps resource type to k8s_node for k8s mem and cpu utilization alerts

### DIFF
--- a/terraform/gcp/modules/monitoring/infra/alerts.tf
+++ b/terraform/gcp/modules/monitoring/infra/alerts.tf
@@ -267,7 +267,7 @@ resource "google_monitoring_alert_policy" "k8s_container_memory_allocatable_util
 
       comparison      = "COMPARISON_GT"
       duration        = "0s"
-      filter          = "metric.type=\"kubernetes.io/node/memory/allocatable_utilization\" resource.type=\"k8s_container\""
+      filter          = "metric.type=\"kubernetes.io/node/memory/allocatable_utilization\" resource.type=\"k8s_node\""
       threshold_value = "0.9"
 
       trigger {
@@ -309,7 +309,7 @@ resource "google_monitoring_alert_policy" "k8s_container_cpu_allocatable_utiliza
 
       comparison      = "COMPARISON_GT"
       duration        = "0s"
-      filter          = "metric.type=\"kubernetes.io/node/cpu/allocatable_utilization\" resource.type=\"k8s_container\""
+      filter          = "metric.type=\"kubernetes.io/node/cpu/allocatable_utilization\" resource.type=\"k8s_node\""
       threshold_value = "0.9"
 
       trigger {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Should fix https://github.com/sigstore/public-good-instance/actions/runs/4418888250/jobs/7746598967