### PR TITLE
Update kind images to v0.17.0, add k8s 1.26.

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -73,7 +73,7 @@ jobs:
     - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2
 
     - name: Setup Cluster
-      uses: chainguard-dev/actions/setup-kind@52eca3baf7c09ec1dbc4195449779fa59cc618e6
+      uses: chainguard-dev/actions/setup-kind@cc7afeaca6e5871be191ecc1b8bce10274bc1ee4
       id: kind
       with:
         k8s-version: ${{ matrix.k8s-version }}
@@ -83,7 +83,7 @@ jobs:
     - name: Setup Knative
       uses: chainguard-dev/actions/setup-knative@main
       with:
-        version: "1.7.x"
+        version: "1.8.x"
         serving-features: >
           {
             "kubernetes.podspec-fieldref": "enabled"

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -27,6 +27,7 @@ jobs:
           - v1.23.x
           - v1.24.x
           - v1.25.x
+          - v1.26.x
 
         leg:
           - fulcio rekor ctlog e2e
@@ -75,7 +76,7 @@ jobs:
     - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2
 
     - name: Setup Cluster
-      uses: chainguard-dev/actions/setup-kind@52eca3baf7c09ec1dbc4195449779fa59cc618e6
+      uses: chainguard-dev/actions/setup-kind@cc7afeaca6e5871be191ecc1b8bce10274bc1ee4
       id: kind
       with:
         k8s-version: ${{ matrix.k8s-version }}
@@ -85,7 +86,7 @@ jobs:
     - name: Setup Knative
       uses: chainguard-dev/actions/setup-knative@main
       with:
-        version: "1.7.x"
+        version: "1.8.x"
         serving-features: >
           {
             "kubernetes.podspec-fieldref": "enabled"

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -24,6 +24,8 @@ jobs:
           - v1.23.x
           - v1.24.x
           - v1.25.x
+          # TODO: need release w/ 1.26 support first.
+          # - v1.26.x
         release-version:
           - "latest-release" # Test explicitly with latest
         go-version:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -24,6 +24,8 @@ jobs:
           - v1.23.x
           - v1.24.x
           - v1.25.x
+          # TODO: enable after next release.
+          # - 1.26.x
         leg:
           - fulcio rekor ctlog e2e
         go-version:
@@ -49,6 +51,7 @@ jobs:
     - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
 
     - name: Setup Cluster
+      # TODO: update after next release.
       uses: chainguard-dev/actions/setup-kind@52eca3baf7c09ec1dbc4195449779fa59cc618e6
       id: kind
       with:
@@ -59,7 +62,7 @@ jobs:
     - name: Setup Knative
       uses: chainguard-dev/actions/setup-knative@main
       with:
-        version: "1.7.x"
+        version: "1.8.x"
         serving-features: >
           {
             "kubernetes.podspec-fieldref": "enabled"

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: true
     default: 'cluster.local'
   k8s-version:
-    description: 'kubernetes version to install (v1.23.x, v1.24.x, v1.25.x), default: v1.24.x'
+    description: 'kubernetes version to install (v1.23.x, v1.24.x, v1.25.x, v1.26.x), default: v1.24.x'
     required: true
     default: 'v1.24.x'
 runs:

--- a/config/fulcio/fulcio/200-configmap.yaml
+++ b/config/fulcio/fulcio/200-configmap.yaml
@@ -9,7 +9,7 @@ data:
     {
       "OIDCIssuers": {
         "https://kubernetes.default.svc.cluster.local": {
-          "IssuerURL": "https://kubernetes.default.svc.cluster.local",
+          "IssuerURL": "https://kubernetes.default.svc",
           "ClientID": "sigstore",
           "Type": "kubernetes"
         },

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -68,18 +68,23 @@ done
 KIND_VERSION="v0.15.0"
 case ${K8S_VERSION} in
   v1.23.x)
-    K8S_VERSION="1.23.10"
-    KIND_IMAGE_SHA="sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12"
+    K8S_VERSION="1.23.13"
+    KIND_IMAGE_SHA="sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61"
     KIND_IMAGE="kindest/node:v${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   v1.24.x)
-    K8S_VERSION="1.24.4"
-    KIND_IMAGE_SHA="sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98"
+    K8S_VERSION="1.24.7"
+    KIND_IMAGE_SHA="sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
     KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
     ;;
   v1.25.x)
-    K8S_VERSION="1.25.0"
-    KIND_IMAGE_SHA="sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf"
+    K8S_VERSION="1.25.3"
+    KIND_IMAGE_SHA="sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+    KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
+    ;;
+  v1.26.x)
+    K8S_VERSION="1.26.0"
+    KIND_IMAGE_SHA="sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352"
     KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
     ;;
   *) echo "Unsupported version: ${K8S_VERSION}"; exit 1 ;;

--- a/hack/setup-scaffolding-from-release.sh
+++ b/hack/setup-scaffolding-from-release.sh
@@ -58,7 +58,7 @@ if [ "${MINOR}" -ge 5 ]; then
   INSTALL_TSA="true"
 fi
 
-# Since the behaviour on oidc is different on k8s <1.23, check to see if we
+# Since the behaviour on oidc is different on certain k8s versions, check to see if we
 # need to do some mucking with the Fulcio config
 NEED_TO_UPDATE_FULCIO_CONFIG="false"
 K8S_SERVER_VERSION=$(kubectl version -ojson | yq '.serverVersion.minor' -)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Updates kind images to match [kind release v0.17.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0), plus adds support for kubernetes 1.26.0.

Updates chainguard-dev/actions/setup-kind to
cc7afeaca6e5871be191ecc1b8bce10274bc1ee4 to add support for k8s 1.26, but not for actions that use the release version, since that pulls in https://github.com/chainguard-dev/actions/commit/52c91a31f977804d9cab66b866d2d9a22a0c9148 which messes with the expected OIDC issuer (removes `.cluster.local` suffix) - this may cause issues to the e2e test once the next release is pushed.

Updates installed Knative version to 1.8.x to update
HorizontalPodAutoscaler to v2, since these were removed in k8s 1.26.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Adds support for k8s v1.26.x with v1.26.0
- Updates k8s v1.25.x to v1.25.3
- Updates k8s v1.24.x to v1.24.7
- Updates k8s v1.23.x to v1.23.13

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Updated the actions input description. Not sure if there's any other place I should update.