### PR TITLE
add flag to specify where to put GCS logs

### DIFF
--- a/terraform/gcp/modules/rekor/storage.tf
+++ b/terraform/gcp/modules/rekor/storage.tf
@@ -26,6 +26,13 @@ resource "google_storage_bucket" "attestation" {
   versioning {
     enabled = true
   }
+
+  dynamic "logging" {
+    for_each = var.gcs_logging_enabled ? [1] : []
+    content {
+      log_bucket = var.gcs_logging_bucket
+    }
+  }
 }
 
 // GCS Bucket 

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -56,6 +56,18 @@ variable "storage_class" {
   default     = "REGIONAL"
 }
 
+variable "gcs_logging_enabled" {
+  type        = bool
+  description = "enable/disable logging of GCS bucket traffic"
+  default     = false
+}
+
+variable "gcs_logging_bucket" {
+  description = "name of GCS bucket where storage logs will be written"
+  type        = string
+  default     = ""
+}
+
 // KMS
 variable "rekor_keyring_name" {
   type        = string

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -60,9 +60,11 @@ module "tuf" {
   region     = var.tuf_region == "" ? var.region : var.tuf_region
   project_id = var.project_id
 
-  tuf_bucket         = var.tuf_bucket
-  tuf_preprod_bucket = var.tuf_preprod_bucket
-  storage_class      = var.tuf_storage_class
+  tuf_bucket          = var.tuf_bucket
+  tuf_preprod_bucket  = var.tuf_preprod_bucket
+  gcs_logging_enabled = var.gcs_logging_enabled
+  gcs_logging_bucket  = var.gcs_logging_bucket
+  storage_class       = var.tuf_storage_class
 
   depends_on = [
     module.project_roles
@@ -199,9 +201,11 @@ module "rekor" {
   kms_location       = "global"
 
   // Storage
-  attestation_bucket = var.attestation_bucket
-  attestation_region = var.attestation_region == "" ? var.region : var.attestation_region
-  storage_class      = var.attestation_storage_class
+  attestation_bucket  = var.attestation_bucket
+  attestation_region  = var.attestation_region == "" ? var.region : var.attestation_region
+  gcs_logging_enabled = var.gcs_logging_enabled
+  gcs_logging_bucket  = var.gcs_logging_bucket
+  storage_class       = var.attestation_storage_class
 
   dns_zone_name      = var.dns_zone_name
   dns_domain_name    = var.dns_domain_name

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -331,3 +331,15 @@ variable "gke_autoscaling_resource_limits_resource_mem_max" {
   type    = number
   default = 16
 }
+
+variable "gcs_logging_enabled" {
+  type        = bool
+  description = "enable/disable logging of GCS bucket traffic"
+  default     = false
+}
+
+variable "gcs_logging_bucket" {
+  description = "name of GCS bucket where storage logs will be written"
+  type        = string
+  default     = ""
+}

--- a/terraform/gcp/modules/tuf/tuf.tf
+++ b/terraform/gcp/modules/tuf/tuf.tf
@@ -57,6 +57,13 @@ resource "google_storage_bucket" "tuf" {
       days_since_noncurrent_time = 730
     }
   }
+
+  dynamic "logging" {
+    for_each = var.gcs_logging_enabled ? [1] : []
+    content {
+      log_bucket = var.gcs_logging_bucket
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_member" "public_tuf_member" {
@@ -94,6 +101,13 @@ resource "google_storage_bucket" "tuf_preprod" {
     }
     condition {
       days_since_noncurrent_time = 730
+    }
+  }
+
+  dynamic "logging" {
+    for_each = var.gcs_logging_enabled ? [1] : []
+    content {
+      log_bucket = var.gcs_logging_bucket
     }
   }
 }

--- a/terraform/gcp/modules/tuf/variables.tf
+++ b/terraform/gcp/modules/tuf/variables.tf
@@ -43,3 +43,15 @@ variable "storage_class" {
   description = "Storage class for TUF root bucket."
   default     = "REGIONAL"
 }
+
+variable "gcs_logging_enabled" {
+  type        = bool
+  description = "enable/disable logging of GCS bucket traffic"
+  default     = false
+}
+
+variable "gcs_logging_bucket" {
+  description = "name of GCS bucket where storage logs will be written"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
#### Summary
This adds the ability to enable logging on GCS buckets to analyze client traffic.