### PR TITLE
disable flow logging in VPC subnets

### DIFF
--- a/terraform/gcp/modules/network/network.tf
+++ b/terraform/gcp/modules/network/network.tf
@@ -59,11 +59,6 @@ resource "google_compute_subnetwork" "subnetwork" {
     ip_cidr_range = "10.2.0.0/20"
   }
 
-  log_config {
-    aggregation_interval = "INTERVAL_10_MIN"
-    flow_sampling        = 0.5
-    metadata             = "INCLUDE_ALL_METADATA"
-  }
   depends_on = [google_compute_network.network]
 }
 


### PR DESCRIPTION
#### Summary
This disables the VPC flow logging in subnets defined within the private networks deployed.