### PR TITLE
Swapping use of external metric to managed prometheus metric

### DIFF
--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -204,7 +204,7 @@ resource "google_monitoring_alert_policy" "prober_verification" {
 
       comparison      = "COMPARISON_GT"
       duration        = "0s"
-      filter          = "resource.type = \"k8s_container\" AND metric.type = \"external.googleapis.com/prometheus/verification\" AND metric.labels.verified = \"false\""
+      filter          = "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/verification/unknown\" AND metric.labels.verified = \"false\""
       threshold_value = "0"
 
       trigger {
@@ -213,7 +213,7 @@ resource "google_monitoring_alert_policy" "prober_verification" {
       }
     }
 
-    display_name = "Kubernetes Container - external/prometheus/verification"
+    display_name = "Kubernetes Container - prometheus/verification"
   }
 
   documentation {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This removes the only reference to an external.googleapis.com metric in our repos to enable fully swapping to only managed prometheus metric collection in gcp.