### PR TITLE
reduce number of uptime checks for rekor

### DIFF
--- a/terraform/gcp/modules/monitoring/rekor/variables.tf
+++ b/terraform/gcp/modules/monitoring/rekor/variables.tf
@@ -65,9 +65,7 @@ variable "notification_channel_ids" {
 variable "api_endpoints_get" {
   type = list(string)
   default = [
-    "/",
     "/api/v1/log",
-    "/api/v1/log/publicKey",
   ]
 }
 


### PR DESCRIPTION
#### Summary
There are currently 3 API endpoints being checked as part of GCP uptime:

1. `/`: returns a static HTML page, and essentially tests that the Rekor server pod is up and running
2. `/api/v1/log`: returns information about all known log shards, including a signed tree head (STH). This by default also checks the health of the backing Trillian instance, as well as the configured KMS signer.
3. `/api/v1/log/publicKey`: returns the public key which can be used to verify the STH. The public key is cached in memory of the Rekor server pod, so this test is equivalent to test number 1 above.

This PR drops uptime checks 1 and 3 which do not provide additional uptime information over test number 2.