### PR TITLE
Change the domains in fulcio config map to match each other

### DIFF
--- a/config/fulcio/fulcio/200-configmap.yaml
+++ b/config/fulcio/fulcio/200-configmap.yaml
@@ -9,7 +9,7 @@ data:
     {
       "OIDCIssuers": {
         "https://kubernetes.default.svc.cluster.local": {
-          "IssuerURL": "https://kubernetes.default.svc",
+          "IssuerURL": "https://kubernetes.default.svc.cluster.local",
           "ClientID": "sigstore",
           "Type": "kubernetes"
         },


### PR DESCRIPTION

#### Summary
This change is to address a startup issue in fulcio. See details at https://github.com/sigstore/scaffolding/issues/622

#### Release Note
This is a small change of config. This looks like it might have been fixed twice because there are sections in the scripts like this
```
# Install Fulcio and wait for it to come up
echo '::group:: Install Fulcio'
if [ "${NEED_TO_UPDATE_FULCIO_CONFIG}" == "true" ]; then
  echo "Fixing Fulcio config"
  cp config/fulcio/fulcio/200-configmap.yaml ./200-configmap.yaml
  # The sed works differently in mac and other places, so just shuffle
  # files around for now.
  sed 's@https://kubernetes.default.svc.cluster.local@https://kubernetes.default.svc@' config/fulcio/fulcio/200-configmap.yaml > ./200-configmap-new.yaml
  mv ./200-configmap-new.yaml config/fulcio/fulcio/200-configmap.yaml
fi
make ko-apply-fulcio
echo '::endgroup::'
```
Where the change in this PR would be reverted for k8s < 1.24.

CC @vaikas 
