### PR TITLE
Labeling severity for low priority alerts

### DIFF
--- a/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/terraform/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -130,6 +130,10 @@ resource "google_monitoring_alert_policy" "ca_service_cert_expiration_alert" {
     mime_type = "text/markdown"
   }
 
+  user_labels = {
+    severity = "warning"
+  }
+
   enabled               = "true"
   notification_channels = local.notification_channels
   project               = var.project_id

--- a/terraform/gcp/modules/monitoring/infra/alerts.tf
+++ b/terraform/gcp/modules/monitoring/infra/alerts.tf
@@ -60,6 +60,7 @@ resource "google_monitoring_alert_policy" "ssl_cert_expiry_alert" {
   user_labels = {
     uptime  = "ssl_cert_expiration"
     version = "1"
+    severity = "warning"
   }
 }
 
@@ -370,6 +371,10 @@ resource "google_monitoring_alert_policy" "redis_memory_usage" {
   documentation {
     content   = "Redis using >90% of max memory. You may need to allocate more."
     mime_type = "text/markdown"
+  }
+
+  user_labels = {
+    severity = "warning"
   }
 
   enabled               = "true"

--- a/terraform/gcp/modules/monitoring/infra/alerts.tf
+++ b/terraform/gcp/modules/monitoring/infra/alerts.tf
@@ -58,8 +58,8 @@ resource "google_monitoring_alert_policy" "ssl_cert_expiry_alert" {
   project               = var.project_id
 
   user_labels = {
-    uptime  = "ssl_cert_expiration"
-    version = "1"
+    uptime   = "ssl_cert_expiration"
+    version  = "1"
     severity = "warning"
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
PagerDuty now understands manually labeled severities. By default, alerts will fire with critical severity and high urgency, but we can manually label alerts with severities of "warning" or "info" for alerts which should have low urgency for the purposes of paging oncallers.