### PR TITLE
allow redis cluster size to be set in variable

### DIFF
--- a/terraform/gcp/modules/redis/main.tf
+++ b/terraform/gcp/modules/redis/main.tf
@@ -66,7 +66,7 @@ resource "google_redis_instance" "index" {
   display_name   = "Rekor Index Instance"
   name           = "rekor-index"
   tier           = "STANDARD_HA"
-  memory_size_gb = 30 // Usage as of 2023/05/22 is 15 GiB
+  memory_size_gb = var.memory_size_gb
   redis_version  = "REDIS_6_X"
 
   region                  = var.region // Used for naming, location determined by location_id

--- a/terraform/gcp/modules/redis/variables.tf
+++ b/terraform/gcp/modules/redis/variables.tf
@@ -38,3 +38,9 @@ variable "cluster_name" {
   type    = string
   default = ""
 }
+
+variable "memory_size_gb" {
+  type        = number
+  default     = 30
+  description = "size of memory allocated to redis cluster in whole GB"
+}

--- a/terraform/gcp/modules/rekor/rekor.tf
+++ b/terraform/gcp/modules/rekor/rekor.tf
@@ -37,7 +37,8 @@ module "redis" {
   region     = var.region
   project_id = var.project_id
 
-  cluster_name = var.cluster_name
+  cluster_name   = var.cluster_name
+  memory_size_gb = var.redis_cluster_memory_size_gb
 
   network = var.network
 }

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -101,3 +101,9 @@ variable "load_balancer_ipv4" {
   description = "IPv4 adddress of external load balancer"
   type        = string
 }
+
+variable "redis_cluster_memory_size_gb" {
+  description = "size of redis cluster expressed in whole GB"
+  type        = number
+  default     = 30
+}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -211,6 +211,8 @@ module "rekor" {
   dns_domain_name    = var.dns_domain_name
   load_balancer_ipv4 = module.network.external_ipv4_address
 
+  redis_cluster_memory_size_gb = var.redis_cluster_memory_size_gb
+
   depends_on = [
     module.network,
     module.gke-cluster,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -343,3 +343,9 @@ variable "gcs_logging_bucket" {
   type        = string
   default     = ""
 }
+
+variable "redis_cluster_memory_size_gb" {
+  description = "size of redis cluster (for rekor) expressed in whole GB"
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
