### PR TITLE
Add GCP Pub/Sub topic for new entry events

### DIFF
--- a/terraform/gcp/modules/pubsub_topic/outputs.tf
+++ b/terraform/gcp/modules/pubsub_topic/outputs.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "pubsub_topic_url" {
+  value = "gcppubsub://projects/${google_pubsub_topic.topic.project}/topics/${google_pubsub_topic.topic.name}"
+}

--- a/terraform/gcp/modules/pubsub_topic/pubsub.tf
+++ b/terraform/gcp/modules/pubsub_topic/pubsub.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_pubsub_topic" "topic" {
+  name    = var.pubsub_topic_name
+  project = var.project_id
+}
+
+data "google_iam_policy" "topic_iam" {
+  binding {
+    role    = "roles/pubsub.publisher"
+    members = ["serviceAccount:${var.publisher_sa_email}"]
+  }
+  binding {
+    role    = "roles/pubsub.subscriber"
+    members = var.pubsub_topic_consumers
+  }
+}
+
+resource "google_pubsub_topic_iam_policy" "topic_iam" {
+  project     = google_pubsub_topic.topic.project
+  topic       = google_pubsub_topic.topic.name
+  policy_data = data.google_iam_policy.topic_iam
+}

--- a/terraform/gcp/modules/pubsub_topic/variables.tf
+++ b/terraform/gcp/modules/pubsub_topic/variables.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "pubsub_topic_name" {
+  description = "Name of the pubsub topic"
+  type        = string
+}
+
+variable "pubsub_topic_consumers" {
+  description = "IAM members that can consume messages from the topic"
+  type        = list(string)
+}
+
+variable "publisher_sa_email" {
+  description = "The service account that can publish meessages to the topic"
+  type        = string
+}
+
+variable "project_id" {
+  description = "The project to create the pubsub resources in"
+  type        = string
+}

--- a/terraform/gcp/modules/rekor/rekor.tf
+++ b/terraform/gcp/modules/rekor/rekor.tf
@@ -43,6 +43,18 @@ module "redis" {
   network = var.network
 }
 
+module "newentry_pubsub_topic" {
+  source = "../pubsub_topic"
+
+  count = length(var.new_entry_pubsub_consumers) > 0 ? 1 : 0
+
+  project_id = var.project_id
+
+  pubsub_topic_name      = "new-entry"
+  publisher_sa_email     = google_service_account.rekor-sa.email
+  pubsub_topic_consumers = var.new_entry_pubsub_consumers
+}
+
 resource "google_dns_record_set" "A_rekor" {
   name = "rekor.${var.dns_domain_name}"
   type = "A"

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -102,3 +102,10 @@ variable "redis_cluster_memory_size_gb" {
   type        = number
   default     = 30
 }
+
+variable "new_entry_pubsub_consumers" {
+  // If this list is empty, the PubSub resources will not be created.
+  description = "The list of IAM principals that can subscribe to events about new entries in the log"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
#### Summary

Adds Terraform for a GCP Pub/Sub topic for new entry events. This will be used by Rekor to publish events for each new entry added to the transparency log.

#### Release Note

* Added Terraform for a GCP Pub/Sub topic for new Rekor entry events.

#### Documentation

N/A.

---

Relates to https://github.com/sigstore/rekor/pull/1580
