### PR TITLE
Bump default knative version to 1.10, remove k8s 1.23

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -33,7 +33,7 @@ inputs:
   knative-version:
     description: 'Version of Knative to install (1.1.0, 1.1.1, etc.)'
     required: true
-    default: '1.6.0'
+    default: '1.10.0'
   registry-name:
     description: 'Name of the registry to install (registry.local)'
     required: true

--- a/config/fulcio/fulcio/200-configmap.yaml
+++ b/config/fulcio/fulcio/200-configmap.yaml
@@ -9,7 +9,7 @@ data:
     {
       "OIDCIssuers": {
         "https://kubernetes.default.svc.cluster.local": {
-          "IssuerURL": "https://kubernetes.default.svc",
+          "IssuerURL": "https://kubernetes.default.svc.cluster.local",
           "ClientID": "sigstore",
           "Type": "kubernetes"
         },

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -34,7 +34,7 @@ done
 
 # Defaults
 K8S_VERSION="v1.24.x"
-KNATIVE_VERSION="1.6.0"
+KNATIVE_VERSION="1.10.0"
 REGISTRY_NAME="registry.local"
 REGISTRY_PORT="5001"
 CLUSTER_SUFFIX="cluster.local"
@@ -67,11 +67,6 @@ done
 # The version map correlated with this version of KinD
 KIND_VERSION="v0.20.0"
 case ${K8S_VERSION} in
-  v1.23.x)
-    K8S_VERSION="1.23.17"
-    KIND_IMAGE_SHA="sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb"
-    KIND_IMAGE="kindest/node:v${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
   v1.24.x)
     K8S_VERSION="1.24.15"
     KIND_IMAGE_SHA="sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab"


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Version skew is high enough in Kubernetes that there are CRDs being removed that make the k8s + knative versions incompatible.

Standardize on supported k8s versions: https://kubernetes.io/releases/ (>= 1.24).

Default knative to v1.10.0 (which has a MIN_KUBERNETES_VERSION of 1.24): https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md#upcoming-releases

Undo issuer change made in https://github.com/sigstore/scaffolding/commit/0bcfba714c4e78858b0828821042a0c96066c500

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Dropped support for Kubernetes 1.23

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
