### PR TITLE
filter tests to save time on terraform-only PRs

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -3,6 +3,8 @@ name: Key rotation for Fulcio E2E Tests
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'terraform/**'
 
 permissions: read-all
 

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -3,6 +3,8 @@ name: Fulcio&Rekor E2E Tests
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+    - 'terraform/**'
 
 permissions: read-all
 

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -3,6 +3,8 @@ name: Test github action with TUF
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'terraform/**'
 
 defaults:
   run:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -3,6 +3,8 @@ name: Fulcio&Rekor E2E Tests Using Release
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'terraform/**'
 
 defaults:
   run:


### PR DESCRIPTION
this change adds `paths-ignore` filters to make terraform-only changes run faster

Fixes: #699 