### PR TITLE
Fix broken tuf presubmit

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -101,7 +101,11 @@ runs:
 
       echo "Installing sigstore scaffolding @ ${tag}"
       curl -fLo /tmp/setup-scaffolding-from-release.sh https://github.com/sigstore/scaffolding/releases/download/${tag}/setup-scaffolding-from-release.sh
+      # Temp hack to address issuer mismatch issue.
+      # Can be removed with the next release, after v0.6.5
+      sed -i "s@kubectl apply -f \"\${FULCIO}\"@curl -Ls \"\${FULCIO}\" | sed 's#\"IssuerURL\": \"https://kubernetes.default.svc\",#\"IssuerURL\": \"https://kubernetes.default.svc.cluster.local\",#' | kubectl apply -f -@" /tmp/setup-scaffolding-from-release.sh
       chmod u+x /tmp/setup-scaffolding-from-release.sh
+      cat /tmp/setup-scaffolding-from-release.sh
       /tmp/setup-scaffolding-from-release.sh --release-version ${tag}
       TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
       echo "TUF_MIRROR=$TUF_MIRROR" >> $GITHUB_ENV

--- a/hack/setup-scaffolding-from-release.sh
+++ b/hack/setup-scaffolding-from-release.sh
@@ -16,6 +16,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 # Default
 RELEASE_VERSION="v0.6.3"
@@ -94,8 +95,10 @@ if [ "${NEED_TO_UPDATE_FULCIO_CONFIG}" == "true" ]; then
   echo "Fixing Fulcio config for < 1.23.X Kubernetes"
   curl -Ls "${FULCIO}" | sed 's@https://kubernetes.default.svc.cluster.local@https://kubernetes.default.svc@' | kubectl apply -f -
 else
-  kubectl apply -f "${FULCIO}"
+  curl -Ls "${FULCIO}" | sed 's@"IssuerURL": "https://kubernetes.default.svc",@"IssuerURL": "https://kubernetes.default.svc.cluster.local",@' | kubectl apply -f -
 fi
+
+kubectl get -n fulcio-system cm fulcio-config -o json
 
 echo '::group:: Wait for Fulcio ready'
 kubectl wait --timeout 5m -n fulcio-system --for=condition=Complete jobs --all


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

try fixing broken tuf presubmit

presubmit fulcio failing with

> FATAL[0m	app/serve.go:209	error loading --config-path=/etc/fulcio-config/config.json: provider https://kubernetes.default.svc: oidc: issuer did not match the issuer returned by provider, expected "https://kubernetes.default.svc" got "https://kubernetes.default.svc.cluster.local"

The presubmit uses the latest release shell script, so added a temp hack to sed needed fix and checking in the fix to the shell script that would be picked up with the next release.

My guess is this is triggered by the last release picking up fulcio v1.3.4, was v1.0.0 before



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
