### PR TITLE
expose GKE monitoring components as variable

### DIFF
--- a/terraform/gcp/modules/gke_cluster/cluster.tf
+++ b/terraform/gcp/modules/gke_cluster/cluster.tf
@@ -90,7 +90,7 @@ resource "google_container_cluster" "cluster" {
     enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
   }
   monitoring_config {
-    enable_components = ["SYSTEM_COMPONENTS"]
+    enable_components = var.monitoring_components
 
     managed_prometheus {
       enabled = var.managed_prometheus

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -216,6 +216,6 @@ variable "managed_prometheus" {
 }
 
 variable "monitoring_components" {
-  type    = list
+  type    = list(any)
   default = ["SYSTEM_COMPONENTS"]
 }

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -216,6 +216,6 @@ variable "managed_prometheus" {
 }
 
 variable "monitoring_components" {
-  type    = list(any)
+  type    = list(string)
   default = ["SYSTEM_COMPONENTS"]
 }

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -214,3 +214,8 @@ variable "managed_prometheus" {
   type    = bool
   default = true
 }
+
+variable "monitoring_components" {
+  type    = list
+  default = ["SYSTEM_COMPONENTS"]
+}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -140,6 +140,8 @@ module "gke-cluster" {
 
   bastion_ip_address = module.bastion.ip_address
 
+  monitoring_components = var.cluster_monitoring_components
+
   depends_on = [
     module.network,
     module.bastion,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -345,3 +345,9 @@ variable "redis_cluster_memory_size_gb" {
   type        = number
   default     = 30
 }
+
+variable "cluster_monitoring_components" {
+  description = "The GKE components exposing metrics. Supported values include: SYSTEM_COMPONENTS, APISERVER, CONTROLLER_MANAGER, and SCHEDULER."
+  type        = list
+  default     = ["SYSTEM_COMPONENTS"]
+}

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -348,6 +348,6 @@ variable "redis_cluster_memory_size_gb" {
 
 variable "cluster_monitoring_components" {
   description = "The GKE components exposing metrics. Supported values include: SYSTEM_COMPONENTS, APISERVER, CONTROLLER_MANAGER, and SCHEDULER."
-  type        = list
+  type        = list(any)
   default     = ["SYSTEM_COMPONENTS"]
 }

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -348,6 +348,6 @@ variable "redis_cluster_memory_size_gb" {
 
 variable "cluster_monitoring_components" {
   description = "The GKE components exposing metrics. Supported values include: SYSTEM_COMPONENTS, APISERVER, CONTROLLER_MANAGER, and SCHEDULER."
-  type        = list(any)
+  type        = list(string)
   default     = ["SYSTEM_COMPONENTS"]
 }


### PR DESCRIPTION
exposes cluster config parameter for monitoring components per https://cloud.google.com/stackdriver/docs/solutions/gke/managing-metrics#control-plane-metrics