### PR TITLE
Fix CodeQL path filtering

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,14 +30,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 
+      - name: Filter paths
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            gocode:
+              - 'pkg/**'
+              - 'cmd/**'
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
+        if: steps.changes.outputs.gocode == 'true'
         uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4
         with:
           languages: '${{ matrix.language }}'
 
-      - run: |
+      - name: Build
+        if: steps.changes.outputs.gocode == 'true'
+        run: |
           make build
 
       - name: Perform CodeQL Analysis
+        if: steps.changes.outputs.gocode == 'true'
         uses: github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'terraform/**'
   schedule:
     - cron: '32 8 * * 2'
 


### PR DESCRIPTION
This reverts commit 4d6984b8dd70ba2abb0da91b70dc682f2ee310a4.

Branch protection rules require the CodeQL check. This change uses `dorny/paths-filter@v2` to filter the path as a step in the workflow so that the required check still runs.

This blocks https://github.com/sigstore/scaffolding/pull/757 which is a terraform-only change.

Signed-off-by: Cody Soyland <codysoyland@github.com>