### PR TITLE
Adding back alerts for DB memory consumption

### DIFF
--- a/terraform/gcp/modules/monitoring/infra/alerts.tf
+++ b/terraform/gcp/modules/monitoring/infra/alerts.tf
@@ -93,7 +93,7 @@ resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization_warning" {
   }
   display_name = "Cloud SQL Database CPU Utilization > 80%"
   documentation {
-    content   = "Cloud SQL Database CPU Utilization is >80%. Please increase CPU capacity."
+    content   = "Cloud SQL Database CPU Utilization is >80%. Please increase CPU capacity via the database tier (https://cloud.google.com/sql/docs/mysql/instance-settings)."
     mime_type = "text/markdown"
   }
   enabled               = "true"
@@ -132,9 +132,97 @@ resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization" {
   }
   display_name = "Cloud SQL Database CPU Utilization > 90%"
   documentation {
-    content   = "Cloud SQL Database CPU Utilization is >90%. Please increase CPU capacity."
+    content   = "Cloud SQL Database CPU Utilization is >90%. Please increase CPU capacity via the database tier (https://cloud.google.com/sql/docs/mysql/instance-settings)."
     mime_type = "text/markdown"
   }
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+}
+
+# Cloud SQL Database Memory Utilization > 90%
+resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization_warning" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_MEAN"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "0s"
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/memory/utilization\" resource.type=\"cloudsql_database\""
+      threshold_value = "0.9"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Cloud SQL Database - Memory utilization [MEAN]"
+  }
+
+  display_name = "Cloud SQL Database Memory Utilization > 90%"
+
+  documentation {
+    content   = "Cloud SQL Database Memory Utilization is >90%. Please increase memory capacity via the database tier (https://cloud.google.com/sql/docs/mysql/instance-settings)."
+    mime_type = "text/markdown"
+  }
+
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+
+  user_labels = {
+    severity = "warning"
+  }
+}
+
+# Cloud SQL Database Memory Utilization > 95%
+resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_MEAN"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "0s"
+      filter          = "metric.type=\"cloudsql.googleapis.com/database/memory/utilization\" resource.type=\"cloudsql_database\""
+      threshold_value = "0.95"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Cloud SQL Database - Memory utilization [MEAN]"
+  }
+
+  display_name = "Cloud SQL Database Memory Utilization > 95%"
+
+  documentation {
+    content   = "Cloud SQL Database Memory Utilization is >95%. Please increase memory capacity via the database tier (https://cloud.google.com/sql/docs/mysql/instance-settings)."
+    mime_type = "text/markdown"
+  }
+
   enabled               = "true"
   notification_channels = local.notification_channels
   project               = var.project_id


### PR DESCRIPTION
We now have a better understanding of expected values, so we are creating a low severity alert at 90% and high severity at 95%.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
