### PR TITLE
add cloudProfiler role to rekor-sa

### DIFF
--- a/terraform/gcp/modules/rekor/service_accounts.tf
+++ b/terraform/gcp/modules/rekor/service_accounts.tf
@@ -41,3 +41,10 @@ resource "google_project_iam_member" "rekor_kms_member" {
   member     = "serviceAccount:${google_service_account.rekor-sa.email}"
   depends_on = [google_service_account.rekor-sa]
 }
+
+resource "google_project_iam_member" "rekor_profiler_agent" {
+  project    = var.project_id
+  role       = "roles/cloudprofiler.agent"
+  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
+  depends_on = [google_service_account.rekor-sa]
+}


### PR DESCRIPTION
SA running rekor needs cloud profiler agent role to upload data per https://cloud.google.com/profiler/docs/profiling-go#gke