### PR TITLE
switch to static base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,5 @@
 ---
-defaultBaseImage: cgr.dev/chainguard/alpine-base:latest
+defaultBaseImage: gcr.io/distroless/static-debian12:nonroot
 baseImageOverrides:
   github.com/sigstore/scaffolding/cmd/cloudsqlproxy: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.7.0-alpine
 


### PR DESCRIPTION
cgr.dev/chainguard/alpine-base:latest is no longer being updated, and we don't need the extra footprint of alpine-base, so switching to a static base image.

Closes: #773 