### PR TITLE
Use issued certificate in request to Rekor

### DIFF
--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -17,6 +17,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"log"
@@ -194,11 +197,17 @@ func runProbers(ctx context.Context, freq int, runOnce bool) {
 			}
 		}
 		if runWriteProber {
-			if err := fulcioWriteEndpoint(ctx); err != nil {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			if err != nil {
+				Logger.Fatalf("failed to generate key: %v", err)
+			}
+
+			cert, err := fulcioWriteEndpoint(ctx, priv)
+			if err != nil {
 				hasErr = true
 				Logger.Errorf("error running fulcio write prober: %v", err)
 			}
-			if err := rekorWriteEndpoint(ctx); err != nil {
+			if err := rekorWriteEndpoint(ctx, cert, priv); err != nil {
 				hasErr = true
 				Logger.Errorf("error running rekor write prober: %v", err)
 			}


### PR DESCRIPTION
This uses the identity-based certificate issued from Fulcio when making a request to Rekor. This will let us filter out requests from the prober when gathering usage metrics.

If the Fulcio request failed, we fallback to a generated key.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
