### PR TITLE
set default autoscaling service_account to not be 'default'

### DIFF
--- a/terraform/gcp/modules/gke_cluster/cluster.tf
+++ b/terraform/gcp/modules/gke_cluster/cluster.tf
@@ -128,6 +128,10 @@ resource "google_container_cluster" "cluster" {
     autoscaling_profile = var.cluster_autoscaling_profile
     enabled             = var.cluster_autoscaling_enabled
 
+    auto_provisioning_defaults = {
+      service_account = google_service_account.gke-sa.email
+    }
+
     resource_limits {
       resource_type = "cpu"
       minimum       = var.resource_limits_resource_cpu_min

--- a/terraform/gcp/modules/gke_cluster/cluster.tf
+++ b/terraform/gcp/modules/gke_cluster/cluster.tf
@@ -128,7 +128,7 @@ resource "google_container_cluster" "cluster" {
     autoscaling_profile = var.cluster_autoscaling_profile
     enabled             = var.cluster_autoscaling_enabled
 
-    auto_provisioning_defaults = {
+    auto_provisioning_defaults {
       service_account = google_service_account.gke-sa.email
     }
 


### PR DESCRIPTION
@vaikas @yrobla I was trying to look at https://github.com/sigstore/public-good-instance/issues/1295 and https://github.com/sigstore/public-good-instance/issues/1301 - I think this will stop using the `default` SA for autoscaling and use the one we wanted instead. PTAL and let me know what you think?