### PR TITLE
clean up terraform for post-install modules

### DIFF
--- a/terraform/gcp/modules/argocd/versions.tf
+++ b/terraform/gcp/modules/argocd/versions.tf
@@ -15,28 +15,16 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.4.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
-    google = {
-      version = ">= 4.11.0, < 4.38.0"
-      source  = "hashicorp/google"
-    }
-    google-beta = {
-      version = ">= 4.11.0, < 4.38.0"
-      source  = "hashicorp/google-beta"
-    }
-    random = {
-      version = ">= 3.1.0, < 3.2.0"
-      source  = "hashicorp/random"
-    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "1.14.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.6.0"
+      version = "2.11.0"
     }
   }
 }

--- a/terraform/gcp/modules/argocd/versions.tf
+++ b/terraform/gcp/modules/argocd/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.3.9"
+  required_version = "1.6.3"
 
   required_providers {
     kubectl = {

--- a/terraform/gcp/modules/external_secrets/external_secrets.tf
+++ b/terraform/gcp/modules/external_secrets/external_secrets.tf
@@ -80,8 +80,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: trillian-system
-  labels:
-    name: trillian-system
 YAML
 }
 

--- a/terraform/gcp/modules/external_secrets/versions.tf
+++ b/terraform/gcp/modules/external_secrets/versions.tf
@@ -15,20 +15,12 @@
  */
 
 terraform {
-  required_version = ">= 1.1.3, < 1.4.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     google = {
-      version = ">= 4.11.0, < 4.38.0"
+      version = ">= 4.37.0"
       source  = "hashicorp/google"
-    }
-    google-beta = {
-      version = ">= 4.11.0, < 4.38.0"
-      source  = "hashicorp/google-beta"
-    }
-    random = {
-      version = ">= 3.1.0, < 3.2.0"
-      source  = "hashicorp/random"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
@@ -36,7 +28,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.6.0"
+      version = "2.11.0"
     }
   }
 }

--- a/terraform/gcp/modules/external_secrets/versions.tf
+++ b/terraform/gcp/modules/external_secrets/versions.tf
@@ -15,11 +15,11 @@
  */
 
 terraform {
-  required_version = ">= 1.3.9"
+  required_version = "1.6.3"
 
   required_providers {
     google = {
-      version = ">= 4.37.0"
+      version = "5.4.0"
       source  = "hashicorp/google"
     }
     kubectl = {


### PR DESCRIPTION
A few changes:

- Remove providers that are not referenced in the module(s)
- Relax constraints to allow upgrades
- Upgrades `hashicorp/helm` provder to latest (`kubectl` provider is already at latest)
- Remove label from `trillian_namespace`, as the [helm-chart we use does not specify this](https://github.com/sigstore/helm-charts/blob/main/charts/trillian/templates/namespace.yaml ) and argocd reverts it immediately after terraform applies the change, and then we constantly get an "update in-place" message while running `terraform plan` 