### PR TITLE
Add support for specifying a different mysql version for each ctlog shard

### DIFF
--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -329,7 +329,7 @@ module "ctlog" {
 module "ctlog_shards" {
   source = "../mysql-shard"
 
-  for_each = toset(var.ctlog_shards)
+  for_each = var.ctlog_shards
 
   instance_name = format("%s-ctlog-%s", var.cluster_name, each.key)
 
@@ -339,7 +339,7 @@ module "ctlog_shards" {
   cluster_name = var.cluster_name
   // NB: These are commented out so that we pick up the defaults
   // for the particular environment consistently.
-  //mysql_database_version  = var.mysql_db_version
+  database_version = each.value["mysql_db_version"]
   //mysql_tier              = var.mysql_tier
 
   replica_zones = var.mysql_replica_zones

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -337,9 +337,11 @@ module "ctlog_shards" {
   region     = var.region
 
   cluster_name = var.cluster_name
-  // NB: These are commented out so that we pick up the defaults
-  // for the particular environment consistently.
+
   database_version = each.value["mysql_db_version"]
+
+  // NB: This is commented out so that we pick up the defaults
+  // for the particular environment consistently.
   //mysql_tier              = var.mysql_tier
 
   replica_zones = var.mysql_replica_zones

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -293,9 +293,12 @@ variable "dns_domain_name" {
 }
 
 variable "ctlog_shards" {
-  type        = list(string)
-  description = "Array of CTLog shards to create. Entry should be something like [2021, 2022], which would then have 2 independent CTLog shards backed by ctlog-2021 and ctlog-2022 Cloud SQL instances."
-  default     = []
+  type = map(object({
+    mysql_db_version = string
+  }))
+
+  description = "Map of CTLog shards to create. If keys are '2022' and '2023', it would create 2 independent CTLog Cloud MySql instances named sigstore-staging-ctlog-2022 and sigstore-staging-ctlog-2023."
+  default     = {}
 }
 
 variable "standalone_mysqls" {


### PR DESCRIPTION
we can use this when we spin up a new ct log shard with mysql 8 to test out trillian/mysql 8 in staging.