### PR TITLE
revert to using latest ko release instead of tip of HEAD

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -74,8 +74,6 @@ jobs:
           ${{ runner.os }}-go-${{ matrix.go-version }}-
 
     - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
-      with:
-        version: tip
 
     - uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 # v3.2.0
 

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -74,8 +74,6 @@ jobs:
           ${{ runner.os }}-go-${{ matrix.go-version }}-
 
     - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
-      with:
-        version: tip
 
     - uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 # v3.2.0
 

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -57,8 +57,6 @@ jobs:
         check-latest: true
 
     - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
-      with:
-        version: tip
 
     - name: Create sample image
       run: |

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -50,8 +50,6 @@ jobs:
         check-latest: true
 
     - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
-      with:
-        version: tip
 
     - name: Setup Cluster
       # TODO: update after next release.


### PR DESCRIPTION
now that the caching issues appear fix, let's revert back to original behavior of installing latest published release of ko