### PR TITLE
Explicitly export zero failures on prober startup

### DIFF
--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -165,6 +165,11 @@ func main() {
 	reg.MustRegister(endpointLatenciesSummary, endpointLatenciesHistogram, verificationCounter)
 	reg.MustRegister(NewVersionCollector("sigstore_prober"))
 
+	// Ensure that we report zeroed failures on verifications.  This allows us to
+	// detect on alert on the "never seen" --> "seen once" transition.
+	verificationCounter.With(prometheus.Labels{verifiedLabel: "false"}).Add(0)
+	verificationCounter.With(prometheus.Labels{verifiedLabel: "true"}).Add(0)
+
 	go runProbers(ctx, frequency, oneTime)
 
 	// Expose the registered metrics via HTTP.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
- Explicitly export `verified=false` metric as 0 on prober startup to help resolve the issue we were facing in #888, where our counter went from "never seen a problem" to "had one failure" and then hung at "had one failure" for 8 hours, causing a continuous alert.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
- The sigstore prober now reports a baseline `0` value for failed verifications on startup.  Previously, it would only report a value for failed verifications after a verification had failed.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

No.
