### PR TITLE
monitoring: change api prober alert

### DIFF
--- a/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
+++ b/terraform/gcp/modules/monitoring/prober/prober_alerts.tf
@@ -199,17 +199,21 @@ resource "google_monitoring_alert_policy" "prober_verification" {
     condition_threshold {
       aggregations {
         alignment_period   = "60s"
-        per_series_aligner = "ALIGN_SUM"
+        per_series_aligner = "ALIGN_RATE"
       }
 
       comparison      = "COMPARISON_GT"
-      duration        = "0s"
-      filter          = "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/verification/unknown\" AND metric.labels.verified = \"false\""
+      duration        = "60s"
+      filter          = "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/verification/unknown:counter\" AND metric.labels.verified = \"false\""
       threshold_value = "0"
 
+      // When there are no responses we get no data instead of "0" in the
+      // metric. This flag treats lack of data as 0 so incidents autoresolve
+      // correctly.
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
+
       trigger {
-        count   = "1"
-        percent = "0"
+        count = "1"
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

I got paged again by the alert testing the creation of a rekor entry and verifying it. (`Policy: API Prober: Rekor write correctness verifier returned &#39;false&#39; within the last 60s`) 

I decided to change the alert to check the counter metric and also add `EVALUATION_MISSING_DATA_NO_OP` condition.

With this new change the metric resets once the alert has been fired as you can see below:

<img width="1266" alt="Screenshot 2023-12-06 at 15 03 40" src="https://github.com/sigstore/scaffolding/assets/3602792/88be0bf7-1944-4100-86b3-2b3475172876">



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
