### PR TITLE
chore: add support for kubernetes version 1.29

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -30,6 +30,7 @@ jobs:
           - v1.26.x
           - v1.27.x
           - v1.28.x
+          - v1.29.x
 
         leg:
           - fulcio-key-rotation

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -30,6 +30,7 @@ jobs:
           - v1.26.x
           - v1.27.x
           - v1.28.x
+          - v1.29.x
 
         leg:
           - fulcio rekor ctlog e2e

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -27,6 +27,7 @@ jobs:
           - v1.26.x
           - v1.27.x
           - v1.28.x
+          - v1.29.x
         release-version:
           - "main" # Test explicitly with latest
         go-version:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -27,6 +27,7 @@ jobs:
           - v1.26.x
           - v1.27.x
           - v1.28.x
+          - v1.29.x
         leg:
           - fulcio rekor ctlog e2e
         go-version:

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -45,7 +45,7 @@ inputs:
     required: true
     default: 'cluster.local'
   k8s-version:
-    description: 'kubernetes version to install (v1.25.x, v1.26.x, v1.27.x, v1.28.x), default: v1.25.x'
+    description: 'kubernetes version to install (v1.25.x, v1.26.x, v1.27.x, v1.28.x, v1.29.x), default: v1.25.x'
     required: true
     default: 'v1.25.x'
 runs:

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -103,6 +103,12 @@ case ${K8S_VERSION} in
     KIND_IMAGE_SHA="sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
     KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
     ;;
+  v1.29.x)
+    K8S_VERSION="1.29.0"
+    KNATIVE_VERSION="1.12.0"
+    KIND_IMAGE_SHA="sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570"
+    KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
+    ;;
   *) echo "Unsupported version: ${K8S_VERSION}"; exit 1 ;;
 esac
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
We are using this github action, but are getting an error with kubernetes version 1.29.0. Since Kubernetes 1.29.0 is officially out, this GHA should support it. 

This PR adds support for kubernetes version 1.29.0

cc @bobcallaway 
#### Release Note
`added support for kubernetes version 1.29`
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
Added support for kubernetes version 1.29.x
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
