### PR TITLE
trims tsa certs

### DIFF
--- a/cmd/tuf/server/main.go
+++ b/cmd/tuf/server/main.go
@@ -93,7 +93,8 @@ func main() {
 				}
 				for k, v := range certFiles {
 					logging.FromContext(ctx).Infof("Got tsa cert file %s", k)
-					files[k] = v
+					trimmedCert := strings.TrimSpace(string(v))
+					files[k] = []byte(trimmedCert)
 				}
 			} else {
 				files[file.Name()] = fileBytes


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The TUF server hosts all other targets without a newline except for the TSA certs. This PR ensures there is no new line added to the end of the file when splitting the TSA cert-chain.

#### Release Note
- Removes newline from TSA certs when splitting TSA cert-chain

#### Documentation
n/a
