### PR TITLE
modules/tuf: Add legacyBucketReader role for TUF SA

### DIFF
--- a/terraform/gcp/modules/tuf/tuf.tf
+++ b/terraform/gcp/modules/tuf/tuf.tf
@@ -75,8 +75,13 @@ resource "google_storage_bucket_iam_member" "public_tuf_member" {
 }
 
 resource "google_storage_bucket_iam_member" "tuf_sa_editor" {
+  for_each = toset([
+    "roles/storage.objectUser",
+    "roles/storage.legacyBucketReader"
+  ])
+
   bucket = google_storage_bucket.tuf.name
-  role   = "roles/storage.objectUser"
+  role   = each.key
   member = format("serviceAccount:%s@%s.iam.gserviceaccount.com", var.tuf_service_account_name, var.project_id)
 
   depends_on = [google_storage_bucket.tuf, google_service_account.tuf-sa]
@@ -129,8 +134,13 @@ resource "google_storage_bucket_iam_member" "public_tuf_preprod_member" {
 }
 
 resource "google_storage_bucket_iam_member" "tuf_sa_preprod_editor" {
+  for_each = toset([
+    "roles/storage.objectUser",
+    "roles/storage.legacyBucketReader"
+  ])
+
   bucket = google_storage_bucket.tuf_preprod.name
-  role   = "roles/storage.objectUser"
+  role   = each.key
   member = format("serviceAccount:%s@%s.iam.gserviceaccount.com", var.tuf_service_account_name, var.project_id)
 
   depends_on = [google_storage_bucket.tuf_preprod, google_service_account.tuf-sa]


### PR DESCRIPTION
root-signing-staging uses "gcloud rsync" to upload files. This apparently [fails without "storage.buckets.get"](https://github.com/sigstore/root-signing-staging/issues/67)

The root cause is likely a gcloud SDK bug
(https://issuetracker.google.com/issues/323465176) but adding legacyBucketReader as a workaround seems harmless.

I'm not a terraform wizard but this "for each" mechanism seems to be used elsewhere for similar purposes.

Fixes sigstore/root-signing-staging#67
