### PR TITLE
Make security groups and attestations optional

### DIFF
--- a/terraform/gcp/modules/gke_cluster/cluster.tf
+++ b/terraform/gcp/modules/gke_cluster/cluster.tf
@@ -145,8 +145,11 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  authenticator_groups_config {
-    security_group = var.security_group
+  dynamic "authenticator_groups_config" {
+    for_each = var.security_group == "" ? [] : [1]
+    content {
+      security_group = var.security_group
+    }
   }
 
   depends_on = [google_project_service.service]

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -223,4 +223,5 @@ variable "monitoring_components" {
 variable "security_group" {
   description = "Name of security group used for Google Groups RBAC within GKE Cluster"
   type        = string
+  default     = ""
 }

--- a/terraform/gcp/modules/rekor/storage.tf
+++ b/terraform/gcp/modules/rekor/storage.tf
@@ -16,6 +16,7 @@
 
 // Attestation bucket and relevant IAM
 resource "google_storage_bucket" "attestation" {
+  count    = var.enable_attestations ? 1 : 0
   name     = var.attestation_bucket
   location = var.attestation_region == "" ? var.region : var.attestation_region
   project  = var.project_id
@@ -37,7 +38,8 @@ resource "google_storage_bucket" "attestation" {
 
 // GCS Bucket 
 resource "google_storage_bucket_iam_member" "rekor_gcs_member" {
-  bucket     = google_storage_bucket.attestation.name
+  count      = var.enable_attestations ? 1 : 0
+  bucket     = google_storage_bucket.attestation[count.index].name
   role       = "roles/storage.objectAdmin"
   member     = "serviceAccount:${google_service_account.rekor-sa.email}"
   depends_on = [google_storage_bucket.attestation, google_service_account.rekor-sa]

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -39,8 +39,15 @@ variable "network" {
 }
 
 // Storage
+variable "enable_attestations" {
+  type        = bool
+  default     = true
+  description = "enable/disable storage for attestations"
+}
+
 variable "attestation_bucket" {
   type        = string
+  default     = ""
   description = "Name of GCS bucket for attestation."
 }
 


### PR DESCRIPTION
RBAC security groups and rekor attestations are not needed for development use cases, and require a lot of overhead to set up. Make these attributes optional.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
