### PR TITLE
drop k8s 1.25/26 releases due to eol and add tests with go1.22

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -26,11 +26,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.25.x
-          - v1.26.x
           - v1.27.x
           - v1.28.x
           - v1.29.x
+          - v1.30.x
 
         leg:
           - fulcio-key-rotation

--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -29,13 +29,13 @@ jobs:
           - v1.27.x
           - v1.28.x
           - v1.29.x
-          - v1.30.x
 
         leg:
           - fulcio-key-rotation
 
         go-version:
           - 1.21.x
+          - 1.22.x
 
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -29,13 +29,13 @@ jobs:
           - v1.27.x
           - v1.28.x
           - v1.29.x
-          - v1.30.x
 
         leg:
           - fulcio rekor ctlog e2e
 
         go-version:
           - 1.21.x
+          - 1.22.x
 
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -26,11 +26,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.25.x
-          - v1.26.x
           - v1.27.x
           - v1.28.x
           - v1.29.x
+          - v1.30.x
 
         leg:
           - fulcio rekor ctlog e2e

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -23,11 +23,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.25.x
-          - v1.26.x
           - v1.27.x
           - v1.28.x
           - v1.29.x
+          - v1.30.x
         release-version:
           - "main" # Test explicitly with latest
         go-version:

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -26,11 +26,11 @@ jobs:
           - v1.27.x
           - v1.28.x
           - v1.29.x
-          - v1.30.x
         release-version:
           - "main" # Test explicitly with latest
         go-version:
           - 1.21.x
+          - 1.22.x
         leg:
           - test github action with TUF
     env:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -26,11 +26,11 @@ jobs:
           - v1.27.x
           - v1.28.x
           - v1.29.x
-          - v1.30.x
         leg:
           - fulcio rekor ctlog e2e
         go-version:
           - 1.21.x
+          - 1.22.x
 
     env:
       RELEASE_VERSION: "v0.6.9"

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -23,11 +23,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.25.x
-          - v1.26.x
           - v1.27.x
           - v1.28.x
           - v1.29.x
+          - v1.30.x
         leg:
           - fulcio rekor ctlog e2e
         go-version:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,13 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: '1.21'
           check-latest: true
           cache: true
+
       - name: Install addlicense
         run: go install github.com/google/addlicense@latest
+
       - name: Check license headers
         run: |
           set -e
@@ -31,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
 
@@ -39,12 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: '1.21'
           check-latest: true
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@38e1018663fa5173f3968ea0777460d3de38f256 # v5.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.54
+          version: v1.57

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,4 +45,4 @@ issues:
   max-same-issues: 0
 run:
   issues-exit-code: 1
-  timeout: 10m
+  timeout: 15m

--- a/cmd/getoidctoken/main.go
+++ b/cmd/getoidctoken/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	http.HandleFunc("/", tokenWriter(env.FileName))
 	/* #nosec G114 */
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	if err := http.ListenAndServe(":8080", nil); err != nil { //nolint: gosec
 		panic(err)
 	}
 }

--- a/cmd/tuf/server/main.go
+++ b/cmd/tuf/server/main.go
@@ -141,7 +141,7 @@ func main() {
 	http.Handle("/", fs)
 
 	/* #nosec G114 */
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	if err := http.ListenAndServe(":8080", nil); err != nil { //nolint: gosec
 		panic(err)
 	}
 }

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -65,48 +65,24 @@ done
 
 # The version map correlated with this version of KinD
 # KNATIVE versions are set from https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md
-KIND_VERSION="v0.20.0"
+KIND_VERSION="v0.22.0"
 case ${K8S_VERSION} in
-  v1.23.x)
-    K8S_VERSION="1.23.17"
-    KNATIVE_VERSION="1.6.0"
-    KIND_IMAGE_SHA="sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb"
-    KIND_IMAGE="kindest/node:v${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.24.x)
-    K8S_VERSION="1.24.15"
-    KNATIVE_VERSION="1.6.0"
-    KIND_IMAGE_SHA="sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab"
-    KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
-    ;;
-  v1.25.x)
-    K8S_VERSION="1.25.11"
-    KNATIVE_VERSION="1.11.3"
-    KIND_IMAGE_SHA="sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8"
-    KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
-    ;;
-  v1.26.x)
-    K8S_VERSION="1.26.6"
-    KNATIVE_VERSION="1.12.0"
-    KIND_IMAGE_SHA="sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
-    KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
-    ;;
   v1.27.x)
-    K8S_VERSION="1.27.3"
+    K8S_VERSION="1.27.11"
     KNATIVE_VERSION="1.12.0"
-    KIND_IMAGE_SHA="sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+    KIND_IMAGE_SHA="sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843"
     KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
     ;;
   v1.28.x)
-    K8S_VERSION="1.28.0"
+    K8S_VERSION="1.28.7"
     KNATIVE_VERSION="1.12.0"
-    KIND_IMAGE_SHA="sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
+    KIND_IMAGE_SHA="sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58"
     KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
     ;;
   v1.29.x)
-    K8S_VERSION="1.29.0"
+    K8S_VERSION="1.29.2"
     KNATIVE_VERSION="1.12.0"
-    KIND_IMAGE_SHA="sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570"
+    KIND_IMAGE_SHA="sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
     KIND_IMAGE=kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}
     ;;
   *) echo "Unsupported version: ${K8S_VERSION}"; exit 1 ;;

--- a/pkg/ctlog/config_test.go
+++ b/pkg/ctlog/config_test.go
@@ -98,7 +98,8 @@ KTkomoSY/OxE/5doBCACehThH+96joWfgC0rXi9qAwZ6hwIMJAKy
 	// openssl ec -in privkey.pem -out privatekey_encrypted.pem -aes256
 	// And encrypted with this supersecretpassword
 	existingEncryptedPrivateKeyPassword = "supersecretpassword"
-	existingEncryptedPrivateKey         = `
+	//nolint: gosec
+	existingEncryptedPrivateKey = `
 -----BEGIN EC PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
 DEK-Info: AES-256-CBC,3C33CA88DF439D434ABDB2DD03491BEC


### PR DESCRIPTION
#### Summary
- drop k8s 1.25/26 releases due to eol and add 1.30 
- update golangci-lint to v1.57.x 