### PR TITLE
Add database for rekor search indexes

### DIFF
--- a/terraform/gcp/modules/mysql/outputs.tf
+++ b/terraform/gcp/modules/mysql/outputs.tf
@@ -22,13 +22,13 @@ output "trillian_serviceaccount" {
 // Used when setting up the GKE cluster to talk to MySQL.
 output "mysql_instance" {
   description = "The generated name of the Cloud SQL instance"
-  value       = google_sql_database_instance.trillian.name
+  value       = google_sql_database_instance.sigstore.name
 }
 
 // Full connection string for the MySQL DB>
 output "mysql_connection" {
   description = "The connection string dynamically generated for storage inside the Kubernetes configmap"
-  value       = format("%s:%s:%s", var.project_id, var.region, google_sql_database_instance.trillian.name)
+  value       = format("%s:%s:%s", var.project_id, var.region, google_sql_database_instance.sigstore.name)
 }
 
 // MySQL DB username.

--- a/terraform/gcp/modules/mysql/variables.tf
+++ b/terraform/gcp/modules/mysql/variables.tf
@@ -104,6 +104,12 @@ variable "db_name" {
   default     = "trillian"
 }
 
+variable "index_db_name" {
+  type        = string
+  description = "Name for the MySQL database for search indexes."
+  default     = "searchindexes"
+}
+
 variable "database_version" {
   type        = string
   description = "MySQL database version."

--- a/terraform/gcp/modules/rekor/service_accounts.tf
+++ b/terraform/gcp/modules/rekor/service_accounts.tf
@@ -48,3 +48,17 @@ resource "google_project_iam_member" "rekor_profiler_agent" {
   member     = "serviceAccount:${google_service_account.rekor-sa.email}"
   depends_on = [google_service_account.rekor-sa]
 }
+
+resource "google_service_account_iam_member" "gke_sa_iam_member_rekor_server" {
+  service_account_id = google_service_account.rekor-sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[rekor-system/rekor-server]"
+  depends_on         = [google_service_account.rekor-sa]
+}
+
+resource "google_project_iam_member" "db_admin_member_rekor" {
+  project    = var.project_id
+  role       = "roles/cloudsql.client"
+  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
+  depends_on = [google_service_account.rekor-sa]
+}


### PR DESCRIPTION
Update the mysql and rekor modules to instantiate a new database in the primary SQL instance for search index storage.

The rekor IAM service accounts are bound to their GKE equivalents and given permission to access the Cloud SQL instance, which makes the cloud-sql-proxy sidecar in the Rekor deployment work.

The "trillian" database instance resource is renamed to "sigstore" since the instance now encompasses two databases, one of which is not for trillian.

The mysql module creates a trillian mysql user, which is not an IAM user. This user already has effectively admin grants on the SQL instance, so it is capable of connecting to the new instance and creating a new user named for the new database would not reduce the overall privileges, so we reuse the trillian mysql user for the new database.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
