### PR TITLE
Make terraform more configurable

### DIFF
--- a/terraform/gcp/modules/ctlog/main.tf
+++ b/terraform/gcp/modules/ctlog/main.tf
@@ -29,9 +29,10 @@ resource "google_project_service" "service" {
 }
 
 resource "google_dns_record_set" "A_ctfe" {
-  name = "ctfe.${var.dns_domain_name}"
-  type = "A"
-  ttl  = 60
+  count = var.dns_domain_name == "" ? 0 : 1
+  name  = "ctfe.${var.dns_domain_name}"
+  type  = "A"
+  ttl   = 60
 
   project      = var.project_id
   managed_zone = var.dns_zone_name

--- a/terraform/gcp/modules/dex/main.tf
+++ b/terraform/gcp/modules/dex/main.tf
@@ -29,9 +29,10 @@ resource "google_project_service" "service" {
 }
 
 resource "google_dns_record_set" "A_dex" {
-  name = "oauth2.${var.dns_domain_name}"
-  type = "A"
-  ttl  = 60
+  count = var.dns_domain_name == "" ? 0 : 1
+  name  = "oauth2.${var.dns_domain_name}"
+  type  = "A"
+  ttl   = 60
 
   project      = var.project_id
   managed_zone = var.dns_zone_name

--- a/terraform/gcp/modules/fulcio/fulcio.tf
+++ b/terraform/gcp/modules/fulcio/fulcio.tf
@@ -28,9 +28,10 @@ module "ca" {
 }
 
 resource "google_dns_record_set" "A_fulcio" {
-  name = "fulcio.${var.dns_domain_name}"
-  type = "A"
-  ttl  = 60
+  count = var.dns_domain_name == "" ? 0 : 1
+  name  = "fulcio.${var.dns_domain_name}"
+  type  = "A"
+  ttl   = 60
 
   project      = var.project_id
   managed_zone = var.dns_zone_name

--- a/terraform/gcp/modules/gke_cluster/cluster.tf
+++ b/terraform/gcp/modules/gke_cluster/cluster.tf
@@ -66,7 +66,7 @@ resource "google_container_cluster" "cluster" {
     }
     tags            = [local.cluster_network_tag]
     service_account = google_service_account.gke-sa.email
-    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    oauth_scopes    = var.oauth_scopes
   }
 
   resource_labels = {

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -225,3 +225,9 @@ variable "security_group" {
   type        = string
   default     = ""
 }
+
+variable "oauth_scopes" {
+  description = "OAuth scopes to assign to the cluster node config"
+  type        = list(string)
+  default     = ["https://www.googleapis.com/auth/cloud-platform"]
+}

--- a/terraform/gcp/modules/rekor/rekor.tf
+++ b/terraform/gcp/modules/rekor/rekor.tf
@@ -56,9 +56,10 @@ module "newentry_pubsub_topic" {
 }
 
 resource "google_dns_record_set" "A_rekor" {
-  name = "rekor.${var.dns_domain_name}"
-  type = "A"
-  ttl  = 60
+  count = var.dns_domain_name == "" ? 0 : 1
+  name  = "rekor.${var.dns_domain_name}"
+  type  = "A"
+  ttl   = 60
 
   project      = var.project_id
   managed_zone = var.dns_zone_name

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -152,6 +152,8 @@ module "gke-cluster" {
 
   security_group = var.gke_cluster_security_group
 
+  oauth_scopes = var.gke_oauth_scopes
+
   depends_on = [
     module.network,
     module.bastion,

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -60,6 +60,7 @@ module "tuf" {
 
   tuf_bucket          = var.tuf_bucket
   tuf_preprod_bucket  = var.tuf_preprod_bucket
+  tuf_bucket_member   = var.tuf_bucket_member
   gcs_logging_enabled = var.gcs_logging_enabled
   gcs_logging_bucket  = var.gcs_logging_bucket
   storage_class       = var.tuf_storage_class

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -23,11 +23,8 @@ variable "project_id" {
 }
 
 variable "project_number" {
-  type = string
-  validation {
-    condition     = length(var.project_number) > 0
-    error_message = "Must specify project_number variable."
-  }
+  type    = string
+  default = ""
 }
 
 variable "region" {

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -74,6 +74,12 @@ variable "tuf_preprod_bucket" {
   description = "Name of GCS bucket for preprod/staged TUF root."
 }
 
+variable "tuf_bucket_member" {
+  type        = string
+  description = "User(s) to grant access to the TUF GCS buckets."
+  default     = "allUsers"
+}
+
 variable "tuf_storage_class" {
   type        = string
   description = "Storage class for TUF bucket."

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -405,3 +405,9 @@ variable "gke_cluster_security_group" {
   description = "name of Google Group used for GKE Group RBAC; must be gke-security-groups@<yourdomain>"
   type        = string
 }
+
+variable "gke_oauth_scopes" {
+  description = "OAuth scopes to assign to the cluster node config"
+  type        = list(string)
+  default     = ["https://www.googleapis.com/auth/cloud-platform"]
+}

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -321,11 +321,13 @@ variable "oslogin" {
 variable "dns_zone_name" {
   description = "Name of DNS Zone object in Google Cloud DNS"
   type        = string
+  default     = ""
 }
 
 variable "dns_domain_name" {
   description = "Name of DNS domain name in Google Cloud DNS"
   type        = string
+  default     = ""
 }
 
 variable "ctlog_shards" {

--- a/terraform/gcp/modules/timestamp/timestamp.tf
+++ b/terraform/gcp/modules/timestamp/timestamp.tf
@@ -15,9 +15,10 @@
  */
 
 resource "google_dns_record_set" "A_timestamp" {
-  name = "timestamp.${var.dns_domain_name}"
-  type = "A"
-  ttl  = 60
+  count = var.dns_domain_name == "" ? 0 : 1
+  name  = "timestamp.${var.dns_domain_name}"
+  type  = "A"
+  ttl   = 60
 
   project      = var.project_id
   managed_zone = var.dns_zone_name

--- a/terraform/gcp/modules/tuf/tuf.tf
+++ b/terraform/gcp/modules/tuf/tuf.tf
@@ -69,7 +69,7 @@ resource "google_storage_bucket" "tuf" {
 resource "google_storage_bucket_iam_member" "public_tuf_member" {
   bucket = google_storage_bucket.tuf.name
   role   = "roles/storage.legacyObjectReader"
-  member = "allUsers"
+  member = var.tuf_bucket_member
 
   depends_on = [google_storage_bucket.tuf]
 }
@@ -128,7 +128,7 @@ resource "google_storage_bucket" "tuf_preprod" {
 resource "google_storage_bucket_iam_member" "public_tuf_preprod_member" {
   bucket = google_storage_bucket.tuf_preprod.name
   role   = "roles/storage.legacyObjectReader"
-  member = "allUsers"
+  member = var.tuf_bucket_member
 
   depends_on = [google_storage_bucket.tuf_preprod]
 }

--- a/terraform/gcp/modules/tuf/variables.tf
+++ b/terraform/gcp/modules/tuf/variables.tf
@@ -39,6 +39,12 @@ variable "tuf_preprod_bucket" {
   description = "Name of GCS bucket for preprod/staged TUF root."
 }
 
+variable "tuf_bucket_member" {
+  type        = string
+  description = "User, group, or service account to grant access to the TUF GCS buckets. Use 'allUsers' for general access, or e.g. group:mygroup@myorg.com for granular access."
+  default     = "allUsers"
+}
+
 variable "storage_class" {
   type        = string
   description = "Storage class for TUF root bucket."


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Make the sigstore terraform module more versatile for different types of deployments, especially development/proof of concept/testing deployments. Makes the following changes:

##### Make TUF bucket member configurable

In some cases it may not be desireable to expose the TUF bucket to
'allUsers', and some GCP organizations may restrict it through the
`constraints/storage.publicAccessPrevention` organization policy

##### Make DNS variables optional

For development purposes, a DNS domain may not be necessary, and
configuring one may be overkill for a short-lived proof of concept
deployment, since the registration expiration is not tied to the life of
the project.

##### Make OAuth scopes configurable

GKE applies the user.info access scope to standard clusters, in addition
to the cloud-platform scope[1]. Because of this, if the scaffolding
terraform is used to create a cluster, and then run again after
completion, the one access scope specified in terraform will be in
conflict with the two automatically assigned by GKE. Making this
configurable ensures that terraform can be idempotent if the user
provides the expected scopes for their cluster type.

[1] https://cloud.google.com/kubernetes-engine/docs/how-to/access-scopes

##### Make project_number optional

project_number is only used for monitoring, so if monitoring is not
enabled then it is not needed.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
