### PR TITLE
Add rekor-mysql ExternalSecret

### DIFF
--- a/terraform/gcp/modules/external_secrets/variables.tf
+++ b/terraform/gcp/modules/external_secrets/variables.tf
@@ -37,3 +37,9 @@ variable "mysql_dbname" {
   description = "Name of MySQL database."
   default     = "trillian"
 }
+
+variable "rekor_mysql_dbname" {
+  type        = string
+  description = "Name of the MySQL database for Rekor search indexes."
+  default     = "searchindexes"
+}


### PR DESCRIPTION
Add a kubectl_manifest terraform resource to create an ExternalSecret for rekor to use to connect to the searchindexes MySQL database when using MySQL as the index storage backend.

The username and password are the same as for the trillian database, but they need to be accessible from the rekor-system namespace, so we create another ExternalSecret but it can pull from the same GCP secret.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
