### PR TITLE
Updates for Go and cloud-sql-connectors/cloud-sql-proxy

### DIFF
--- a/.github/workflows/add-remove-new-fulcio.yaml
+++ b/.github/workflows/add-remove-new-fulcio.yaml
@@ -34,7 +34,6 @@ jobs:
           - fulcio-key-rotation
 
         go-version:
-          - 1.21.x
           - 1.22.x
 
     env:

--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -34,7 +34,6 @@ jobs:
           - fulcio rekor ctlog e2e
 
         go-version:
-          - 1.21.x
           - 1.22.x
 
     env:
@@ -46,6 +45,11 @@ jobs:
       COSIGN_EXPERIMENTAL: true
 
     steps:
+    - name: Check out our repo
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      with:
+        path: ./src/github.com/sigstore/scaffolding
+
     - uses: chainguard-dev/actions/setup-mirror@main
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
 
@@ -54,11 +58,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
-
-    - name: Check out our repo
-      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-      with:
-        path: ./src/github.com/sigstore/scaffolding
 
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/prober-test.yml
+++ b/.github/workflows/prober-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: Prober test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
-        go-version: '1.21'
+        go-version: '1.22'
         check-latest: true
 
     - name: Install ko

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -29,7 +29,6 @@ jobs:
         release-version:
           - "main" # Test explicitly with latest
         go-version:
-          - 1.21.x
           - 1.22.x
         leg:
           - test github action with TUF

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,7 +29,6 @@ jobs:
         leg:
           - fulcio rekor ctlog e2e
         go-version:
-          - 1.21.x
           - 1.22.x
 
     env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
           cache: true
 
@@ -46,11 +46,11 @@ jobs:
 
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.57
+          version: v1.58

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,7 @@
 ---
 defaultBaseImage: gcr.io/distroless/static-debian12:nonroot
 baseImageOverrides:
-  github.com/sigstore/scaffolding/cmd/cloudsqlproxy: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.10.1-alpine
+  github.com/sigstore/scaffolding/cmd/cloudsqlproxy: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.10.2-alpine
 
 builds:
   - id: ctlog-createctconfig

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -5,5 +5,5 @@
 # !!!!!!!!!!!!!!
 #
 # If dependabot proposes an update to the container listed below, you should also update the value listed in '.ko.yaml' and cut a new release of scaffolding
-FROM gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.0-alpine as cloud-sql-proxy
+FROM gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.2-alpine as cloud-sql-proxy
 ENV FOO=BAR


### PR DESCRIPTION
#### Summary

- Bump cloud-sql-connectors/cloud-sql-proxy from 2.11.0-alpine to 2.11.2-alpine
- use go1.22


xref: https://github.com/sigstore/scaffolding/pull/1101