### PR TITLE
add ssl_mode given deprecation of require_ssl

### DIFF
--- a/terraform/gcp/modules/mysql-shard/mysql.tf
+++ b/terraform/gcp/modules/mysql-shard/mysql.tf
@@ -40,6 +40,7 @@ resource "google_sql_database_instance" "trillian" {
       ipv4_enabled    = var.ipv4_enabled
       private_network = var.network
       require_ssl     = var.require_ssl
+      ssl_mode        = var.require_ssl ? "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" : "SSL_MODE_UNSPECIFIED"
     }
 
     database_flags {
@@ -80,6 +81,7 @@ resource "google_sql_database_instance" "read_replica" {
       ipv4_enabled    = var.ipv4_enabled
       private_network = var.network
       require_ssl     = var.require_ssl
+      ssl_mode        = var.require_ssl ? "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" : "SSL_MODE_UNSPECIFIED"
     }
 
     database_flags {

--- a/terraform/gcp/modules/mysql/mysql.tf
+++ b/terraform/gcp/modules/mysql/mysql.tf
@@ -126,6 +126,7 @@ resource "google_sql_database_instance" "sigstore" {
       ipv4_enabled    = var.ipv4_enabled
       private_network = var.network
       require_ssl     = var.require_ssl
+      ssl_mode        = var.require_ssl ? "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" : "SSL_MODE_UNSPECIFIED"
     }
 
     database_flags {
@@ -173,6 +174,7 @@ resource "google_sql_database_instance" "read_replica" {
       ipv4_enabled    = var.ipv4_enabled
       private_network = var.network
       require_ssl     = var.require_ssl
+      ssl_mode        = var.require_ssl ? "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" : "SSL_MODE_UNSPECIFIED"
     }
 
     database_flags {


### PR DESCRIPTION
```
╷
│ Warning: Argument is deprecated
│ 
│   with module.sigstore.module.ctlog_shards["2022"].google_sql_database_instance.trillian,
│   on ../../../../../scaffolding/terraform/gcp/modules/mysql-shard/mysql.tf line 42, in resource "google_sql_database_instance" "trillian":
│   42:       require_ssl     = var.require_ssl
│ 
│ `require_ssl` will be fully deprecated in a future major release. For now, please use `ssl_mode` with a compatible `require_ssl` value instead.
│ 
│ (and 2 more similar warnings elsewhere)
╵

```