### PR TITLE
Add v1 Fulcio endpoint to prober

### DIFF
--- a/cmd/prober/prober.go
+++ b/cmd/prober/prober.go
@@ -238,7 +238,12 @@ func runProbers(ctx context.Context, freq int, runOnce bool, fulcioGrpcClient fu
 			cert, err := fulcioWriteEndpoint(ctx, priv)
 			if err != nil {
 				hasErr = true
-				Logger.Errorf("error running fulcio write prober: %v", err)
+				Logger.Errorf("error running fulcio v2 write prober: %v", err)
+			}
+			_, err = fulcioWriteLegacyEndpoint(ctx, priv)
+			if err != nil {
+				hasErr = true
+				Logger.Errorf("error running fulcio v1 write prober: %v", err)
 			}
 			if err := rekorWriteEndpoint(ctx, cert, priv); err != nil {
 				hasErr = true


### PR DESCRIPTION
There is an SLO set up for the /api/v1/signingCert Fulcio endpoint[1], but it is currently reporting "No SLO status data" because the prober was never testing that endpoint. This lead to an outage that went undetected by the monitoring system.

Cosign uses the legacy certificate request endpoint in its Fulcio client[2][3]. This means that the v1 endpoint is likely the most used and therefore an important health indicator. This change adds the v1 endpoint to the prober test, which should populate Prometheus with data which should activate the SLO.

[1] https://github.com/sigstore/scaffolding/blob/8f7aa097e54eabcecbc671818f9eb5f0e723e54b/terraform/gcp/modules/monitoring/fulcio/slo.tf#L79-L83
[2] https://github.com/sigstore/cosign/blob/79db196e2d97e7dfc4d8201ef829d4ce906605a7/cmd/cosign/cli/fulcio/fulcio.go#L32
[3] https://github.com/sigstore/fulcio/blob/07b19da442b418ebcf072ac65a7abb25f0e3d5c8/pkg/api/client.go#L60

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
