### PR TITLE
Generate the TUF repository with consistent_snapshot: true

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -72,7 +72,7 @@ func CreateRepoWithMetadata(ctx context.Context, targets []TargetWithMetadata) (
 		return nil, "", fmt.Errorf("failed to NewRepoIndent: %w", err)
 	}
 
-	if err := r.Init(false); err != nil {
+	if err := r.Init(true); err != nil {
 		return nil, "", fmt.Errorf("failed to Init repo: %w", err)
 	}
 

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -123,7 +123,7 @@ func TestCompressUncompressFS(t *testing.T) {
 			"repository",
 			"targets",
 			"6a0d8ce486b4aa7a2b30bf0940a879a00d1bb2738c4874543e179781d42b8ea1d12f34698dc95b3beeb9785036f7f2272e2fc92b994a04ac59ae458b5f4a2a7c.rekor.pub",
-		)
+		),
 	)
 	if err != nil {
 		t.Errorf("Failed to read the roundtripped rekor %v", err)

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -117,7 +117,14 @@ func TestCompressUncompressFS(t *testing.T) {
 	}
 
 	// As well as, say rekor.pub under targets dir
-	rtRekor, err := os.ReadFile(filepath.Join(dstDir, "repository", "targets", "rekor.pub"))
+	rtRekor, err := os.ReadFile(
+		filepath.Join(
+			dstDir,
+			"repository",
+			"targets",
+			"6a0d8ce486b4aa7a2b30bf0940a879a00d1bb2738c4874543e179781d42b8ea1d12f34698dc95b3beeb9785036f7f2272e2fc92b994a04ac59ae458b5f4a2a7c.rekor.pub",
+		)
+	)
 	if err != nil {
 		t.Errorf("Failed to read the roundtripped rekor %v", err)
 	}


### PR DESCRIPTION
#### Summary

This PR makes the TUF server initialize the TUF repository with `consistent_snapshot: true`. Fixes #1236.

#### Release Note

The TUF server was modified to generate the TUF repository with `consistent_snapshot: true`.

#### Documentation

Probably no need to document other than the release note (?)