### PR TITLE
Set default value for tuf_main_page_suffix

### DIFF
--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -110,7 +110,7 @@ variable "tuf_kms_location" {
 variable "tuf_main_page_suffix" {
   type        = string
   description = "path to tuf bucket's directory index when missing object is treated as potential directories"
-  default     = ""
+  default     = "index.html"
 }
 
 variable "ca_pool_name" {


### PR DESCRIPTION
Both root-signing and root-signing-staging now have a index.html (not a pretty one but the basic info is there), so set a default value here

---

Currently staging env has code to set this value specifically. My assumption is that once this scaffolding is used by the environments, production env will just start using this main page without any changes in the environment itself -- let me know if this is incorrect.
