### PR TITLE
change in-cluster prober to read across all shards (programatically)

### DIFF
--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -27,6 +27,7 @@ type ReadProberCheck struct {
 	SLOEndpoint string            `json:"slo-endpoint"`
 }
 
+// FYI: shard-specific reads are computed in determineShardCoverage
 var RekorEndpoints = []ReadProberCheck{
 	{
 		Endpoint: "/api/v1/log/publicKey",
@@ -34,10 +35,6 @@ var RekorEndpoints = []ReadProberCheck{
 	}, {
 		Endpoint: "/api/v1/log",
 		Method:   GET,
-	}, {
-		Endpoint: "/api/v1/log/entries",
-		Method:   GET,
-		Queries:  map[string]string{"logIndex": "10"},
 	}, {
 		Endpoint: "/api/v1/log/proof",
 		Method:   GET,

--- a/cmd/prober/write.go
+++ b/cmd/prober/write.go
@@ -64,6 +64,7 @@ func setHeaders(req *retryablehttp.Request, token string) {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	// Set the content-type to reflect we're sending JSON.
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", fmt.Sprintf("Sigstore_Scaffolding_Prober/%s", versionInfo.GitVersion))
 	// Set this value (even though it is not coming through an GCP LB) to correlate prober req/response


### PR DESCRIPTION
Dynamically pulls the list of shards from Rekor, chooses a random entry within each shard, and reads those entries. This provides us better operational coverage given each shard is persisted as a different tree.