### PR TITLE
Remove doc section about trusted_root.json

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -384,33 +384,3 @@ vaikas@villes-mbp scaffolding % echo 'eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdG
 ```
 
 Notice our predicate is `foobar test attestation` as was in our predicate file.
-
-## Generating trusted_root.json
-
-The TUF mirror in this stack does not serve a
-[`trusted_root.json`](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_trustroot.proto)
-target, but you can generate one to use with certain sigstore clients.
-
-1. Download and install [trtool](https://github.com/kommendorkapten/trtool).
-
-2. Use `cosign initialize` as described above to download targets from the TUF
-   mirror.
-
-3. Initialize the trusted root with the Fulcio CA:
-
-```
-./trtool init -ca ~/.sigstore/root/targets/fulcio_v1.crt.pem -ca-uri $FULCIO_URL -ca-start $(date -Iseconds) | jq > tr.1.json
-```
-
-4. Add the transparency log and certificate transparency log keys:
-
-```
-./trtool add -f tr.1.json -type ctlog -uri $CTLOG_URL -pem ~/.sigstore/root/targets/ctfe.pub -start $(date -Iseconds) | jq > tr.2.json
-./trtool add -f tr.2.json -type tlog -uri $REKOR_URL -pem ~/.sigstore/root/targets/rekor.pub -start $(date -Iseconds) | jq > trusted_root.json
-```
-
-5. Now the trusted_root.json can be used as input for sigstore clients:
-
-```
-sigstore-go -trustedrootJSONpath trusted_root.json -tufTrustedRoot root.json -artifact=blob -expectedSAN=https://kubernetes.io/namespaces/default/serviceaccounts/default -expectedIssuer=https://kubernetes.default.svc.cluster.local bundle.json
-```


### PR DESCRIPTION
trusted_root.json is now served by the TUF mirror as of 16ae89aa, no need for the user to create it themself.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
