### PR TITLE
enable toggle for DNS-based GKE endpoint

### DIFF
--- a/terraform/gcp/modules/gke_cluster/cluster.tf
+++ b/terraform/gcp/modules/gke_cluster/cluster.tf
@@ -113,6 +113,7 @@ resource "google_container_cluster" "cluster" {
       display_name = var.display_name
       cidr_block   = format("%s/32", var.bastion_ip_address)
     }
+    private_endpoint_enforcement_enabled = var.enable_private_endpoint
   }
 
   // Configure the cluster to have private nodes and private control plane access only
@@ -120,6 +121,14 @@ resource "google_container_cluster" "cluster" {
     enable_private_endpoint = var.enable_private_endpoint
     enable_private_nodes    = var.enable_private_nodes
     master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+  }
+
+  // Configure the cluster to use DNS endpoint configuration
+  // https://cloud.google.com/blog/products/containers-kubernetes/new-dns-based-endpoint-for-the-gke-control-plane
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = var.dns_control_plane_endpoint
+    }
   }
 
   # GKE Dataplane v2 comes with network policy, network policy needs to be disabled to enable dataplane v2.

--- a/terraform/gcp/modules/gke_cluster/outputs.tf
+++ b/terraform/gcp/modules/gke_cluster/outputs.tf
@@ -25,6 +25,11 @@ output "cluster_endpoint" {
   value       = google_container_cluster.cluster.endpoint
 }
 
+output "cluster_dns_endpoint" {
+  description = "Cluster DNS endpoint"
+  value       = google_container_cluster.cluster.control_plane_endpoints_config[0].dns_endpoint_config[0].endpoint
+}
+
 output "cluster_location" {
   description = "Cluster location"
   value       = google_container_cluster.cluster.location

--- a/terraform/gcp/modules/gke_cluster/variables.tf
+++ b/terraform/gcp/modules/gke_cluster/variables.tf
@@ -231,3 +231,9 @@ variable "oauth_scopes" {
   type        = list(string)
   default     = ["https://www.googleapis.com/auth/cloud-platform"]
 }
+
+variable "dns_control_plane_endpoint" {
+  description = "enable DNS-based control plane endpoint"
+  type        = bool
+  default     = false
+}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -154,6 +154,9 @@ module "gke-cluster" {
 
   oauth_scopes = var.gke_oauth_scopes
 
+  enable_private_endpoint    = var.gke_use_ip_endpoint
+  dns_control_plane_endpoint = var.gke_use_dns_endpoint
+
   depends_on = [
     module.network,
     module.bastion,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -423,3 +423,15 @@ variable "gke_oauth_scopes" {
   type        = list(string)
   default     = ["https://www.googleapis.com/auth/cloud-platform"]
 }
+
+variable "gke_use_dns_endpoint" {
+  description = "Use DNS-based control plane endpoint for GKE cluster"
+  type        = bool
+  default     = false
+}
+
+variable "gke_use_ip_endpoint" {
+  description = "Use IP-based control plane endpoint for GKE cluster"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
adds ability to toggle on/off both [DNS-based endpoint](https://cloud.google.com/blog/products/containers-kubernetes/new-dns-based-endpoint-for-the-gke-control-plane) and IP-based endpoint

this would allow us to get rid of the bastion and socks proxies to access the cluster