### PR TITLE
bound rekor endpoint list from growing indefinitely

### DIFF
--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -28,7 +28,7 @@ type ReadProberCheck struct {
 }
 
 // FYI: shard-specific reads are computed in determineShardCoverage
-var RekorEndpoints = []ReadProberCheck{
+var ShardlessRekorEndpoints = []ReadProberCheck{
 	{
 		Endpoint: "/api/v1/log/publicKey",
 		Method:   GET,


### PR DESCRIPTION
since adding the shard-specific tests in https://github.com/sigstore/scaffolding/pull/1333, the list of rekor endpoints was only appended to which causes it to grow indefinitely, as the prober is a long lived process

this was not caught in initial tests as i was only using the `-one-time` value to verify the function