### PR TITLE
Remove Cloud SQL memory utilization > 90% alert

### DIFF
--- a/terraform/gcp/modules/monitoring/infra/alerts.tf
+++ b/terraform/gcp/modules/monitoring/infra/alerts.tf
@@ -140,52 +140,6 @@ resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization" {
   project               = var.project_id
 }
 
-# Cloud SQL Database Memory Utilization > 90%
-resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization_warning" {
-  # In the absence of data, incident will auto-close in 7 days
-  alert_strategy {
-    auto_close = "604800s"
-  }
-
-  combiner = "OR"
-
-  conditions {
-    condition_threshold {
-      aggregations {
-        alignment_period   = "300s"
-        per_series_aligner = "ALIGN_MEAN"
-      }
-
-      comparison      = "COMPARISON_GT"
-      duration        = "0s"
-      filter          = "metric.type=\"cloudsql.googleapis.com/database/memory/utilization\" resource.type=\"cloudsql_database\""
-      threshold_value = "0.9"
-
-      trigger {
-        count   = "1"
-        percent = "0"
-      }
-    }
-
-    display_name = "Cloud SQL Database - Memory utilization [MEAN]"
-  }
-
-  display_name = "Cloud SQL Database Memory Utilization > 90%"
-
-  documentation {
-    content   = "Cloud SQL Database Memory Utilization is >90%. Please increase memory capacity via the database tier (https://cloud.google.com/sql/docs/mysql/instance-settings)."
-    mime_type = "text/markdown"
-  }
-
-  enabled               = "true"
-  notification_channels = local.notification_channels
-  project               = var.project_id
-
-  user_labels = {
-    severity = "warning"
-  }
-}
-
 # Cloud SQL Database Memory Utilization > 95%
 resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization" {
   # In the absence of data, incident will auto-close in 7 days


### PR DESCRIPTION
We've been getting a lot of low urgency pages for this alert (~50 in the past day). As discussed in the oncall meeting, this isn't a particularly useful  metric to alert on since MySQL will always use a large amount of memory. CPU usage has been normal, and we have alerts for it, and it's probably a better metric to alert on
