### PR TITLE
add cloud SQL IAM user for trillian mysql connections

### DIFF
--- a/terraform/gcp/modules/mysql/mysql.tf
+++ b/terraform/gcp/modules/mysql/mysql.tf
@@ -253,3 +253,20 @@ resource "google_project_iam_member" "db_iam_auth" {
   member     = "serviceAccount:${google_service_account.dbuser_trillian.email}"
   depends_on = [google_service_account.dbuser_trillian]
 }
+
+resource "google_sql_user" "breakglass_iam_group" {
+  count    = var.breakglass_iam_group != "" ? 1 : 0
+  name     = var.breakglass_iam_group
+  instance = google_sql_database_instance.sigstore.name
+  type     = "CLOUD_IAM_GROUP"
+}
+
+resource "google_project_iam_binding" "breakglass_iam_group_permissions" {
+  for_each = toset([
+    "roles/cloudsql.client",
+    "roles/cloudsql.instanceUser"
+  ])
+  project = var.project_id
+  role    = each.key
+  members = var.breakglass_iam_group != "" ? ["group:${var.breakglass_iam_group}"] : []
+}

--- a/terraform/gcp/modules/mysql/mysql.tf
+++ b/terraform/gcp/modules/mysql/mysql.tf
@@ -239,3 +239,17 @@ resource "google_secret_manager_secret_version" "mysql-database" {
 data "google_secret_manager_secret_version_access" "mysql-password" {
   secret = google_secret_manager_secret.mysql-password.id
 }
+
+// be sure to manually GRANT SELECT, INSERT, CREATE privileges for this user
+resource "google_sql_user" "iam_user" {
+  name     = google_service_account.dbuser_trillian.email
+  instance = google_sql_database_instance.sigstore.name
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+}
+
+resource "google_project_iam_member" "db_iam_auth" {
+  project    = var.project_id
+  role       = "roles/cloudsql.instanceUser"
+  member     = "serviceAccount:${google_service_account.dbuser_trillian.email}"
+  depends_on = [google_service_account.dbuser_trillian]
+}

--- a/terraform/gcp/modules/mysql/variables.tf
+++ b/terraform/gcp/modules/mysql/variables.tf
@@ -127,3 +127,8 @@ variable "collation" {
   description = "collation setting for database"
   default     = "utf8_general_ci"
 }
+
+variable "breakglass_iam_group" {
+  type        = string
+  description = "name of Cloud IAM group to use for database access in case of emergency"
+}

--- a/terraform/gcp/modules/rekor/sql.tf
+++ b/terraform/gcp/modules/rekor/sql.tf
@@ -41,3 +41,20 @@ resource "google_project_iam_member" "db_iam_auth" {
   member     = "serviceAccount:${google_service_account.rekor-sa.email}"
   depends_on = [google_service_account.rekor-sa]
 }
+
+resource "google_sql_user" "breakglass_iam_group" {
+  count    = var.breakglass_iam_group != "" ? 1 : 0
+  name     = var.breakglass_iam_group
+  instance = var.index_database_instance_name
+  type     = "CLOUD_IAM_GROUP"
+}
+
+resource "google_project_iam_binding" "breakglass_iam_group_permissions" {
+  for_each = toset([
+    "roles/cloudsql.client",
+    "roles/cloudsql.instanceUser"
+  ])
+  project = var.project_id
+  role    = each.key
+  members = var.breakglass_iam_group != "" ? ["group:${var.breakglass_iam_group}"] : []
+}

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -121,3 +121,8 @@ variable "index_database_instance_name" {
   description = "name of SQL database instance used to store index lookups"
   type        = string
 }
+
+variable "breakglass_iam_group" {
+  type        = string
+  description = "name of Cloud IAM group to use for database access in case of emergency"
+}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -192,6 +192,7 @@ module "mysql" {
   backup_enabled            = var.mysql_backup_enabled
   binary_log_backup_enabled = var.mysql_binary_log_backup_enabled
 
+  breakglass_iam_group = var.breakglass_sql_iam_group
 
   depends_on = [
     module.network,
@@ -236,6 +237,7 @@ module "rekor" {
   redis_cluster_memory_size_gb = var.redis_cluster_memory_size_gb
 
   index_database_instance_name = module.mysql.mysql_instance
+  breakglass_iam_group         = var.breakglass_sql_iam_group
 
   depends_on = [
     module.network,

--- a/terraform/gcp/modules/sigstore/variables.tf
+++ b/terraform/gcp/modules/sigstore/variables.tf
@@ -435,3 +435,9 @@ variable "gke_use_ip_endpoint" {
   type        = bool
   default     = true
 }
+
+variable "breakglass_sql_iam_group" {
+  description = "Cloud IAM Group that should have database access in case of emergency"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
this creates a new SQL IAM user to the database and adds permissions for it to connect to SQL instances

also creates a CLOUD_IAM_GROUP user for breakglass purposes