### PR TITLE
remove duplicate terraform for bg SQL IAM user

### DIFF
--- a/terraform/gcp/modules/rekor/sql.tf
+++ b/terraform/gcp/modules/rekor/sql.tf
@@ -42,19 +42,24 @@ resource "google_project_iam_member" "db_iam_auth" {
   depends_on = [google_service_account.rekor-sa]
 }
 
-resource "google_sql_user" "breakglass_iam_group" {
-  count    = var.breakglass_iam_group != "" ? 1 : 0
-  name     = var.breakglass_iam_group
-  instance = var.index_database_instance_name
-  type     = "CLOUD_IAM_GROUP"
-}
+/*
+ * this is created in the mysql module, and since rekor and trillian share a SQL instance
+ * there's no need to create it twice
 
-resource "google_project_iam_binding" "breakglass_iam_group_permissions" {
-  for_each = toset([
-    "roles/cloudsql.client",
-    "roles/cloudsql.instanceUser"
-  ])
-  project = var.project_id
-  role    = each.key
-  members = var.breakglass_iam_group != "" ? ["group:${var.breakglass_iam_group}"] : []
-}
+  resource "google_sql_user" "breakglass_iam_group" {
+    count    = var.breakglass_iam_group != "" ? 1 : 0
+    name     = var.breakglass_iam_group
+    instance = var.index_database_instance_name
+    type     = "CLOUD_IAM_GROUP"
+  }
+
+  resource "google_project_iam_binding" "breakglass_iam_group_permissions" {
+    for_each = toset([
+      "roles/cloudsql.client",
+      "roles/cloudsql.instanceUser"
+    ])
+    project = var.project_id
+    role    = each.key
+    members = var.breakglass_iam_group != "" ? ["group:${var.breakglass_iam_group}"] : []
+  }
+*/

--- a/terraform/gcp/modules/rekor/variables.tf
+++ b/terraform/gcp/modules/rekor/variables.tf
@@ -121,8 +121,3 @@ variable "index_database_instance_name" {
   description = "name of SQL database instance used to store index lookups"
   type        = string
 }
-
-variable "breakglass_iam_group" {
-  type        = string
-  description = "name of Cloud IAM group to use for database access in case of emergency"
-}

--- a/terraform/gcp/modules/sigstore/sigstore.tf
+++ b/terraform/gcp/modules/sigstore/sigstore.tf
@@ -237,7 +237,6 @@ module "rekor" {
   redis_cluster_memory_size_gb = var.redis_cluster_memory_size_gb
 
   index_database_instance_name = module.mysql.mysql_instance
-  breakglass_iam_group         = var.breakglass_sql_iam_group
 
   depends_on = [
     module.network,


### PR DESCRIPTION
terraform apply failed because rekor and trillian are sharing a SQL instance therefore the user only needs to be created once