### PR TITLE
workflows: Test the generated trusted_root.json

### DIFF
--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -87,6 +87,19 @@ jobs:
         --certificate-identity "https://kubernetes.io/namespaces/default/serviceaccounts/default" \
         --certificate-oidc-issuer "https://kubernetes.default.svc.cluster.local"
 
+    - name: Sign and verify with signature bundle format and trusted root
+      run: |
+        cosign sign-blob --yes --new-bundle-format=true --bundle=bundle.json --rekor-url ${{ env.REKOR_URL }} --fulcio-url ${{ env.FULCIO_URL }} --identity-token ${{ env.OIDC_TOKEN }} README.md
+
+        # TODO: drop --trusted-root when cosign actually uses trusted root by default
+        cosign verify-blob \
+            --certificate-identity-regexp="https://kubernetes.io/namespaces/default/serviceaccounts/default" \
+            --certificate-oidc-issuer-regexp="https://kubernetes.default.svc.cluster.local" \
+            --bundle=bundle.json  --new-bundle-format \
+            --rekor-url $REKOR_URL \
+            --trusted-root=$HOME/.sigstore/root/targets/trusted_root.json \
+            README.md
+
     - name: Checkout TSA for testing.
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -60,7 +60,7 @@ jobs:
         ./hack/setup-kind.sh \
           --registry-url registry.local:5000 \
           --cluster-suffix cluster.local \
-          --k8s-version ${{ matrix.k8s-version }} ''
+          --k8s-version ${{ matrix.k8s-version }}
 
         ./hack/setup-scaffolding.sh
 

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -37,13 +37,59 @@ jobs:
       KO_DOCKER_REPO: registry.local:5000/knative
 
     steps:
-    - name: Checkout the current action
+    - name: Checkout scaffolding
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Test running the action
-      uses: ./actions/setup
-      with:
-        k8s-version: ${{ matrix.k8s-version }}
-        version: ${{ matrix.release-version }}
+    - name: Setup scaffolding
+      run: |
+        # This is a simplified copy of actions/setup/action.yml: the action cannot really deploy
+        # from the current commit
+
+        set -ex
+
+        # Configure DockerHub mirror
+        tmp=$(mktemp)
+        if [ ! -f /etc/docker/daemon.json ]; then
+          echo '{}' | sudo tee /etc/docker/daemon.json
+        fi
+        jq '."registry-mirrors" = ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmp"
+        sudo mv "$tmp" /etc/docker/daemon.json
+        sudo service docker restart
+
+        echo "Installing kind and knative using setup-kind.sh from current commit"
+
+        ./hack/setup-kind.sh \
+          --registry-url registry.local:5000 \
+          --cluster-suffix cluster.local \
+          --k8s-version ${{ matrix.k8s-version }} ''
+
+        ./hack/setup-scaffolding.sh
+
+        TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
+        echo "TUF_MIRROR=$TUF_MIRROR" >> $GITHUB_ENV
+        # Grab the trusted root
+        kubectl -n tuf-system get secrets tuf-root -ojsonpath='{.data.root}' | base64 -d > ./root.json
+
+        # Make copy of the tuf root in the default namespace for tests
+        kubectl -n tuf-system get secrets tuf-root -oyaml | sed 's/namespace: .*/namespace: default/' | kubectl create -f -
+
+        REKOR_URL=$(kubectl -n rekor-system get ksvc rekor -ojsonpath='{.status.url}')
+        FULCIO_URL=$(kubectl -n fulcio-system get ksvc fulcio -ojsonpath='{.status.url}')
+        FULCIO_GRPC_URL=$(kubectl -n fulcio-system get ksvc fulcio-grpc -ojsonpath='{.status.url}')
+        CTLOG_URL=$(kubectl -n ctlog-system get ksvc ctlog -ojsonpath='{.status.url}')
+        ISSUER_URL=$(kubectl get ksvc gettoken -ojsonpath='{.status.url}')
+        TSA_URL=$(kubectl -n tsa-system get ksvc tsa -ojsonpath='{.status.url}')
+
+        # Grab an OIDC token too.
+        OIDC_TOKEN=$(curl -s $ISSUER_URL)
+        echo "OIDC_TOKEN=$OIDC_TOKEN" >> $GITHUB_ENV
+
+        # And set the env variables for workflow visibility
+        echo "REKOR_URL=$REKOR_URL" >> $GITHUB_ENV
+        echo "FULCIO_URL=$FULCIO_URL" >> $GITHUB_ENV
+        echo "FULCIO_GRPC_URL=$FULCIO_GRPC_URL" >> $GITHUB_ENV
+        echo "CTLOG_URL=$CTLOG_URL" >> $GITHUB_ENV
+        echo "ISSUER_URL=$ISSUER_URL" >> $GITHUB_ENV
+        echo "TSA_URL=$TSA_URL" >> $GITHUB_ENV
 
     # Install cosign
     - name: Install cosign

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -133,9 +133,16 @@ jobs:
         --certificate-identity "https://kubernetes.io/namespaces/default/serviceaccounts/default" \
         --certificate-oidc-issuer "https://kubernetes.default.svc.cluster.local"
 
-    - name: Sign and verify with signature bundle format and trusted root
+    - name: Sign a blob with signature bundle format
       run: |
-        cosign sign-blob --yes --new-bundle-format=true --bundle=bundle.json --rekor-url ${{ env.REKOR_URL }} --fulcio-url ${{ env.FULCIO_URL }} --identity-token ${{ env.OIDC_TOKEN }} README.md
+        cosign sign-blob --yes --new-bundle-format=true --bundle=bundle.json --rekor-url $REKOR_URL --fulcio-url $FULCIO_URL --identity-token $OIDC_TOKEN README.md
+        echo "Bundle:"
+        jq < bundle.json
+
+    - name: Verify blob with signature bundle format using trusted_root.json
+      run: |
+        echo "trust root:"
+        jq < $HOME/.sigstore/root/targets/trusted_root.json
 
         # TODO: drop --trusted-root when cosign actually uses trusted root by default
         cosign verify-blob \

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -287,8 +287,8 @@ func constructTrustedRoot(targets []TargetWithMetadata) (*TargetWithMetadata, er
 }
 
 func pubkeyToTransparencyLogInstance(keyBytes []byte, tm time.Time) (*root.TransparencyLog, string, error) {
-	logID := sha256.Sum256(keyBytes)
 	der, _ := pem.Decode(keyBytes)
+	logID := sha256.Sum256(der.Bytes)
 	key, keyDetails, err := getKeyWithDetails(der.Bytes)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Use cosign to verify that the trust root generated by scaffolding actually works: this currently requires specifying --trusted-root when calling cosign

**DRAFT**: I expect the new test to fail until I add the fix