### PR TITLE
Fix scaffolding trust root

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -176,6 +176,22 @@ jobs:
         --certificate-identity "https://kubernetes.io/namespaces/default/serviceaccounts/default" \
         --certificate-oidc-issuer "https://kubernetes.default.svc.cluster.local"
 
+    - name: Sign a blob with signature bundle format
+      run: |
+        cosign sign-blob --yes --new-bundle-format=true --bundle=bundle.json --rekor-url $REKOR_URL --fulcio-url $FULCIO_URL --identity-token $OIDC_TOKEN README.md
+
+    - name: Verify blob with signature bundle format using trusted_root.json
+      run: |
+        # the trusted_root.json is in the TUF target cache: Use --trusted-root while cosign does not
+        # use it by default
+        cosign verify-blob \
+            --certificate-identity-regexp="https://kubernetes.io/namespaces/default/serviceaccounts/default" \
+            --certificate-oidc-issuer-regexp="https://kubernetes.default.svc.cluster.local" \
+            --bundle=bundle.json  --new-bundle-format \
+            --rekor-url $REKOR_URL \
+            --trusted-root=$HOME/.sigstore/root/targets/trusted_root.json \
+            README.md
+
     # Test with cosign in 'airgapped mode'
     # Uncomment these once modified cosign goes in.
     #- name: Checkout modified cosign for testing.

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -287,8 +287,8 @@ func constructTrustedRoot(targets []TargetWithMetadata) (*TargetWithMetadata, er
 }
 
 func pubkeyToTransparencyLogInstance(keyBytes []byte, tm time.Time) (*root.TransparencyLog, string, error) {
-	logID := sha256.Sum256(keyBytes)
 	der, _ := pem.Decode(keyBytes)
+	logID := sha256.Sum256(der.Bytes)
 	key, keyDetails, err := getKeyWithDetails(der.Bytes)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Scaffolding TUF setup includes a generated trusted_root.json but it is never tested and manual testing implies it is broken
* Add test to verify the issue
* Fix the LogId issue in trusted_root.json
