### PR TITLE
Revert "Fix dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     - "/config/**/*"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: "cloud-sql-connectors/cloud-sql-proxy*"
+- package-ecosystem: docker
+  directories:
+    - "/"
+  schedule:
+    interval: weekly
   allow:
     - dependency-name: "cloud-sql-connectors/cloud-sql-proxy*"
   labels:


### PR DESCRIPTION
Reverts sigstore/scaffolding#1542

this allowed automation to run and apply labels ONLY on the cloud-sql-proxy updates, and separate it out for all other docker images.