### PR TITLE
setup-sigstore-env: Support signingconfig 0.2

### DIFF
--- a/actions/setup-sigstore-env/action.yml
+++ b/actions/setup-sigstore-env/action.yml
@@ -32,6 +32,9 @@ outputs:
   signing-config:
     description: Path to the singning config json file.
     value: ${{ steps.run-containers.outputs.signing-config }}
+  trust-config:
+    description: Path to the trust config json file.
+    value: ${{ steps.run-containers.outputs.trust-config }}
 runs:
   using: composite
   steps:
@@ -64,3 +67,6 @@ runs:
 
         echo "SIGNING_CONFIG=$SIGNING_CONFIG" >> "$GITHUB_ENV"
         echo "signing-config=$SIGNING_CONFIG" >> "$GITHUB_OUTPUT"
+
+        echo "TRUST_CONFIG=$TRUST_CONFIG" >> "$GITHUB_ENV"
+        echo "trust-config=$TRUST_CONFIG" >> "$GITHUB_OUTPUT"

--- a/actions/setup-sigstore-env/run-containers.sh
+++ b/actions/setup-sigstore-env/run-containers.sh
@@ -109,4 +109,5 @@ pushd "$CLONE_DIR" || return
   || return
 export TRUSTED_ROOT="$CLONE_DIR/trusted_root.json"
 export SIGNING_CONFIG="$CLONE_DIR/signing_config.json"
+export TRUST_CONFIG="$CLONE_DIR/trust_config.json"
 popd || return


### PR DESCRIPTION
Updates the SigningConfig version used n setup-sigstore-env. Fixes #1554 

* spit out a SigningConfig v0.2
* Also output TrustConfig (this is just TrustedRoot and SigningConfig combined). This is not really mandatory, just a convenience -- I can leave it out if it looks like unneeeded action API growth.

Note that the run-containers script is still entirely non-configurable: All provided rekor instances will be added to trust root but only the last one is added to signing config -- currently this means rekor-tiles is in SigningConfig
