### PR TITLE
Parallelize service setup

### DIFF
--- a/actions/setup-sigstore-env/run-containers.sh
+++ b/actions/setup-sigstore-env/run-containers.sh
@@ -52,32 +52,26 @@ OWNER_REPOS=(
   "$TIMESTAMP_AUTHORITY_REPO"
   "$REKOR_TILES_REPO"
 )
+procs=${#OWNER_REPOS[@]}
 for owner_repo in "${OWNER_REPOS[@]}"; do
     repo=$(basename "$owner_repo")
     if [[ ! -d $repo ]]; then
-        git clone https://github.com/"${owner_repo}".git
+        echo "'git clone https://github.com/${owner_repo}.git'"
     else
-        pushd "$repo" || return
-        git pull
-        popd || return
+        echo "'cd $repo && git pull'"
     fi
-done
+done | xargs -P "$procs" -l1 bash -c
 export CT_LOG_KEY="$CLONE_DIR/fulcio/config/ctfe/pubkey.pem"
 
 echo "starting services"
 export FULCIO_METRICS_PORT=2113
 for owner_repo in "${OWNER_REPOS[@]}"; do
     repo=$(basename "$owner_repo")
-    pushd "$repo" || return
-    if [[ "$repo" == "fulcio" ]]; then
-      # create the fulcio_default network by running `compose up`.
-      docker compose up -d
-      # then quickly attach the fakeoidc container to the fulcio_default network.
-      docker network inspect fulcio_default | grep fakeoidc || docker network connect --alias "$HOST" fulcio_default fakeoidc || return
-    fi
-    docker compose up --wait || return
-    popd || return
-done
+    echo "'cd $repo && docker compose up --wait'"
+done | xargs -P "$procs" -l1 bash -c
+# The OIDC service is not in the Fulcio docker compose project, so by default its networks are separate.
+# Connect the fakeoidc container to the Fulcio network to enable Fulcio to reach it for token verification.
+docker network inspect fulcio_default | grep fakeoidc || docker network connect --alias "$HOST" fulcio_default fakeoidc || return
 export TSA_URL="http://${HOST}:3004"
 popd || return
 


### PR DESCRIPTION
Speed up the setup-sigstore-env script by downloading and starting all four services in parallel.

This reduces the duration of the setup-sigstore-env action from about 10-11 minutes to about 9 minutes.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
