### PR TITLE
Trigger Prober Unit Test on pull request

### DIFF
--- a/.github/workflows/prober-test.yml
+++ b/.github/workflows/prober-test.yml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
     - 'cmd/prober/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+    - 'cmd/prober/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change allows the Prober Unit Test to be triggered on a pull request as opposed to simply a push.