### PR TITLE
Add Rekor v2 and TSA probers

### DIFF
--- a/.github/workflows/prober-test.yml
+++ b/.github/workflows/prober-test.yml
@@ -18,11 +18,19 @@ permissions:
 
 jobs:
   prober-test:
-    name: 'Prober test'
+    name: 'Prober test (${{ matrix.env }})'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - env: prod
+            args: ""
+          - env: staging
+            args: "--staging"
     steps:
       - name: 'Checkout'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -47,4 +55,4 @@ jobs:
 
       - name: Run prober test
         id: prober-test
-        run: ./prober --one-time --write-prober --logStyle dev
+        run: ./prober --one-time --write-prober --logStyle dev ${{ matrix.args }}

--- a/cmd/prober/endpoints.go
+++ b/cmd/prober/endpoints.go
@@ -55,6 +55,13 @@ var ShardlessRekorEndpoints = []ReadProberCheck{
 	},
 }
 
+var RekorV2ReadEndpoints = []ReadProberCheck{
+	{
+		Endpoint: "/healthz",
+		Method:   GET,
+	},
+}
+
 var FulcioEndpoints = []ReadProberCheck{
 	{
 		Endpoint: "/api/v1/rootCert",

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	chainguard.dev/exitdir v0.0.1
 	filippo.io/edwards25519 v1.1.0
 	github.com/cenkalti/backoff/v3 v3.2.2
+	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7
 	github.com/go-jose/go-jose/v4 v4.1.2
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag/conv v0.24.0
@@ -154,7 +155,6 @@ require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
-	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/cli v28.2.2+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Partially addresses sigstore/rekor-tiles#46

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change adds read and write probers for Rekor v2 and a write prober for a TSA.

This change also adds a prober unit test workflow run using the TUF staging signing config.