### PR TITLE
Add namespace to tesseract images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ ko-resolve:
 	LDFLAGS="$(LDFLAGS)" KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
 	ko build --base-import-paths --platform=all --tags $(OMNIWITNESS_VERSION),$(GIT_TAG),latest --image-refs imagerefs-gcp_omniwitness github.com/transparency-dev/witness/cmd/gcp/omniwitness
 	# Building gcp_tesseract
-	LDFLAGS="$(LDFLAGS)" KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
+	LDFLAGS="$(LDFLAGS)" KO_DOCKER_REPO="$(KO_DOCKER_REPO)/tesseract" \
 	ko build --base-import-paths --platform=all --tags $(TESSERACT_VERSION),$(GIT_TAG),latest --image-refs imagerefs-gcp_tesseract github.com/transparency-dev/tesseract/cmd/tesseract/gcp
 	# Building posix_tesseract
-	LDFLAGS="$(LDFLAGS)" KO_DOCKER_REPO=$(KO_DOCKER_REPO) \
+	LDFLAGS="$(LDFLAGS)" KO_DOCKER_REPO="$(KO_DOCKER_REPO)/tesseract" \
 	ko build --base-import-paths --platform=all --tags $(TESSERACT_VERSION),$(GIT_TAG),latest --image-refs imagerefs-posix_tesseract github.com/transparency-dev/tesseract/cmd/tesseract/posix
 
 .PHONY: ko-resolve-testdata


### PR DESCRIPTION
`ko build` names the image after the name of the package that it's building, which in the case of the two tesseract binaries is just "gcp" and "posix", with no context on what those mean. This change extends the KO_DOCKER_REPO variable to include "tesseract" as part of the repo name, so the full image name will have "tesseract" in it.

When browsing the scaffolding images, both images will still just appear as "gcp" and "posix". The alternative solution to make them more distinguishable in the web UI would be to use `--preserve-import-paths` which would produce an image named
"github.com/transparency-dev/tesseract/cmd/tesseract/gcp", with full name
"ghcr.io/sigstore/scaffolding/tesseract/github.com/transparency-dev/tesseract/cmd/tesseract/gcp".

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
