### PR TITLE
CODEOWNERS: fix formatting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @sigstore/sigstore-oncall
-* @sigstore/infrastructure-team
+* @sigstore/sigstore-oncall @sigstore/infrastructure-team


### PR DESCRIPTION
only the last codeowner line will match if there are two with the same pattern: The codeowners must be on same line to match.
