### PR TITLE
workflows: Allow insecure registries in tests

### DIFF
--- a/.github/workflows/fulcio-rekor-kind.yaml
+++ b/.github/workflows/fulcio-rekor-kind.yaml
@@ -77,6 +77,36 @@ jobs:
 
     - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
+    - name: Set up ko wrapper for insecure registry
+      run: |
+        mkdir -p ${{ github.workspace }}/bin
+        cat <<'EOF' > ${{ github.workspace }}/bin/ko
+        #!/usr/bin/env bash
+        MY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        for dir in ${PATH//:/ }; do
+          if [ "$dir" != "$MY_DIR" ] && [ -x "$dir/ko" ]; then
+            REAL_KO="$dir/ko"
+            break
+          fi
+        done
+        if [ -z "$REAL_KO" ]; then
+          echo "Real ko not found" >&2
+          exit 1
+        fi
+        cmd="$1"
+        shift
+        case "$cmd" in
+          build|publish|resolve|apply)
+            exec "$REAL_KO" "$cmd" --insecure-registry "$@"
+            ;;
+          *)
+            exec "$REAL_KO" "$cmd" "$@"
+            ;;
+        esac
+        EOF
+        chmod +x ${{ github.workspace }}/bin/ko
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
     - uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 
     - name: Setup Cluster

--- a/.github/workflows/test-action-tuf.yaml
+++ b/.github/workflows/test-action-tuf.yaml
@@ -77,7 +77,7 @@ jobs:
           fmt.Println("hello world")
         }
         EOF
-        demoimage=$(ko publish -B example.com/demo-action-with-tuf)
+        demoimage=$(ko publish --insecure-registry -B example.com/demo-action-with-tuf)
         echo "demoimage=$demoimage" >> $GITHUB_ENV
         echo Created image $demoimage
         popd

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -112,7 +112,7 @@ jobs:
           fmt.Println("hello world")
         }
         EOF
-        demoimage=`ko publish -B example.com/demo-with-release`
+        demoimage=`ko publish --insecure-registry -B example.com/demo-with-release`
         echo "demoimage=$demoimage" >> $GITHUB_ENV
         echo Created image $demoimage
         popd


### PR DESCRIPTION
setup-ko installs newest ko. ko 0.19 started bringing in an upgraded go-containerregistry which seems to restrict non-HTTPS use.

* fulcio-rekor-kind: create a "ko" wrapper that allows insecure registries (because there are loads of ko calls being made via Makefile). This script is AI generated
* The other two workflows only make a single ko call: modify the call sites

Fixes #1945 but I'd appreciate if someone more familiar with this setup would decide if this is the right fix -- maybe we do want to change all the places where ko is called to use "--insecure-registry" instead?