### PR TITLE
Retry flaky service builds in setup-sigstore-env

### DIFF
--- a/actions/setup-sigstore-env/run-containers.sh
+++ b/actions/setup-sigstore-env/run-containers.sh
@@ -35,9 +35,28 @@ done
 CLONE_DIR="${CLONE_DIR:-$(mktemp -d)}"
 CWD="$(pwd)"
 
+# retry runs a command up to 3 times with backoff, to ride out transient
+# proxy.golang.org fetch failures during `go mod download` in the service
+# Dockerfiles. Exported so it's usable from the `bash -c` commands xargs
+# spawns below.
+retry() {
+  local -i attempt=1 max_attempts=3 delay=10
+  until "$@"; do
+    if (( attempt >= max_attempts )); then
+      echo "command failed after ${max_attempts} attempts: $*" >&2
+      return 1
+    fi
+    echo "attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s: $*" >&2
+    sleep "$delay"
+    (( attempt += 1 ))
+    (( delay *= 2 ))
+  done
+}
+export -f retry
+
 echo "setting up OIDC provider"
 pushd ./fakeoidc || return
-docker compose up --wait --build
+retry docker compose up --wait --build
 # Tokens will be created with this URL as the token issuer, so that Fulcio can make
 # requests to the fakeoidc container running in Fulcio's network,
 # which will be created later on.
@@ -87,7 +106,7 @@ echo "starting services"
 export FULCIO_METRICS_PORT=2113
 for owner_repo in "${OWNER_REPOS[@]}"; do
   repo=$(basename "$owner_repo")
-  echo "'cd $repo && docker compose up --wait'"
+  echo "'cd $repo && retry docker compose up --wait'"
 done | xargs -P "$procs" -L1 bash -c
 # The fakeoidc service is in a separate Docker network. Connect the fakeoidc container to the Fulcio
 # network to enable Fulcio to reach it for token verification.


### PR DESCRIPTION
Fixes #1970.

`run-containers.sh` clones `fulcio`, `rekor`, `timestamp-authority`, and `rekor-tiles` fresh on every run and brings each up with `docker compose up --wait`, which implicitly builds since no cached image exists for the freshly cloned repo. Those Dockerfiles' `go mod download` step has no retry logic, so a single transient `unexpected EOF` from `proxy.golang.org` on any one of the ~15+ module fetches across the four builds fails the whole job — see #1970 for two independent occurrences (2026-08-18 and 2026-07-30, unrelated commits, same signature) and the 55% recent failure rate on `sigstore-go`'s `main` branch `e2e` workflow.

This wraps the `docker compose up --wait [--build]` calls with a small retry-with-backoff (3 attempts, 10s/20s). Docker's build layer cache means a retry mostly just re-runs the one layer that failed, so this should resolve the large majority of these failures cheaply, without touching the four downstream repos' own Dockerfiles.

Tested:
- `shellcheck actions/setup-sigstore-env/run-containers.sh` — clean (matches this repo's own CI check)
- Unit-tested the `retry()` helper in isolation: succeeds immediately when the command succeeds, succeeds after a transient failure, and correctly fails after exhausting all attempts
- Confirmed the `export -f retry` propagates correctly through `xargs -P N -L1 bash -c`, the exact invocation pattern the script uses for the per-service builds
